### PR TITLE
Make SparseSetBase::~SparseSetBase() definition inlined

### DIFF
--- a/src/Utils/SparseSet.hpp
+++ b/src/Utils/SparseSet.hpp
@@ -21,7 +21,7 @@ namespace Dynamo {
          */
         virtual ~SparseSetBase() = 0;
     };
-    SparseSetBase::~SparseSetBase() = default;
+    inline SparseSetBase::~SparseSetBase() = default;
 
     /**
      * @brief Sparse sets are an alternative to the hash map that allow


### PR DESCRIPTION
This is to prevent duplicate definition issues when compiling demos