### PR TITLE
Implement SparseSet::forall_items() and SparseSet::forall_ids()

### DIFF
--- a/src/Utils/ChannelData.hpp
+++ b/src/Utils/ChannelData.hpp
@@ -11,13 +11,13 @@ namespace Dynamo {
      *
      * @tparam T Type of data
      */
-    template <typename T, typename Container = std::vector<T>>
+    template <typename T>
     class ChannelData {
         /**
          * @brief Data container
          *
          */
-        Container _data;
+        std::vector<T> _data;
 
         /**
          * @brief Number of channels
@@ -49,7 +49,7 @@ namespace Dynamo {
          * @param data     Data buffer
          * @param channels Number of channels
          */
-        ChannelData(Container data, unsigned channels) :
+        ChannelData(std::vector<T> data, unsigned channels) :
             _data(data), _channels(channels), _frames(data.size() / channels) {
             DYN_ASSERT(data.size() % channels == 0);
         }
@@ -57,9 +57,9 @@ namespace Dynamo {
         /**
          * @brief Get the internal data container
          *
-         * @return Container&
+         * @return std::vector<T>&
          */
-        inline Container &data() { return _data; }
+        inline std::vector<T> &data() { return _data; }
 
         /**
          * @brief Get the number of frames

--- a/src/Utils/SparseSet.hpp
+++ b/src/Utils/SparseSet.hpp
@@ -57,7 +57,7 @@ namespace Dynamo {
          * @brief Contains indices to _dense and _pool
          *
          */
-        std::vector<unsigned> _sparse;
+        std::vector<int> _sparse;
 
       public:
         /**
@@ -80,8 +80,8 @@ namespace Dynamo {
             }
 
             // Verify that the sparse and dense arrays are correlated
-            unsigned index = _sparse[key];
-            if (index >= _dense.size() || _dense[index] != id) {
+            int index = _sparse[key];
+            if (index == -1 || index >= _dense.size() || _dense[index] != id) {
                 return -1;
             }
             return index;
@@ -140,8 +140,8 @@ namespace Dynamo {
             }
 
             // Verify that the sparse and dense arrays are correlated
-            unsigned index = _sparse[key];
-            if (index >= _dense.size() || _dense[index] != id) {
+            int index = _sparse[key];
+            if (index == -1 || index >= _dense.size() || _dense[index] != id) {
                 return;
             }
 
@@ -190,11 +190,33 @@ namespace Dynamo {
         /**
          * @brief Apply a function to each member of the set
          *
-         * @param function Function that takes a T object, id, and index
+         * @param function Function that takes a T object and its id
          */
-        void forall(std::function<void(T &item, Id id, int index)> function) {
-            for (int index = 0; index < size(); index++) {
-                function(_pool[index], _dense[index], index);
+        inline void forall(std::function<void(T &item, Id id)> function) {
+            for (int i = 0; i < size(); i++) {
+                function(_pool[i], _dense[i]);
+            }
+        }
+
+        /**
+         * @brief Apply a function to each item in the set
+         *
+         * @param function Function that takes a T object
+         */
+        inline void forall_items(std::function<void(T &item)> function) {
+            for (int i = 0; i < size(); i++) {
+                function(_pool[i]);
+            }
+        }
+
+        /**
+         * @brief Apply a function to each id in the set
+         *
+         * @param function Function that takes an id
+         */
+        inline void forall_ids(std::function<void(Id id)> function) {
+            for (int i = 0; i < size(); i++) {
+                function(_dense[i]);
             }
         }
     };

--- a/tests/SparseSet-Test.cpp
+++ b/tests/SparseSet-Test.cpp
@@ -88,7 +88,7 @@ TEST_CASE("SparseSet mismatched id version", "[SparseSet]") {
     REQUIRE(set.size() == 1);
 }
 
-TEST_CASE("SparseSet foreach", "[SparseSet]") {
+TEST_CASE("SparseSet forall", "[SparseSet]") {
     CharSet set;
     Dynamo::IdTracker tracker;
 
@@ -110,27 +110,36 @@ TEST_CASE("SparseSet foreach", "[SparseSet]") {
 
     REQUIRE(set.size() == 3);
 
-    struct Triplet {
+    struct Pair {
         char &item;
         Dynamo::Id id;
-        int index;
     };
-    std::vector<Triplet> triplets;
-    set.forall([&](char &item, Dynamo::Id id, int index) {
-        triplets.push_back({item, id, index});
+    std::vector<Pair> triplets;
+    std::vector<char> items;
+    std::vector<Dynamo::Id> ids;
+
+    set.forall([&](char &item, Dynamo::Id id) {
+        triplets.push_back({item, id});
     });
+    set.forall_items([&](char &item) { items.push_back(item); });
+    set.forall_ids([&](Dynamo::Id id) { ids.push_back(id); });
 
     REQUIRE(triplets[0].item == 'c');
     REQUIRE(triplets[0].id == c);
-    REQUIRE(triplets[0].index == 0);
+    REQUIRE(items[0] == 'c');
+    REQUIRE(ids[0] == c);
 
     REQUIRE(triplets[1].item == 'b');
     REQUIRE(triplets[1].id == b);
-    REQUIRE(triplets[1].index == 1);
+    REQUIRE(items[1] == 'b');
+    REQUIRE(ids[1] == b);
 
     REQUIRE(triplets[2].item == 'd');
     REQUIRE(triplets[2].id == d);
-    REQUIRE(triplets[2].index == 2);
+    REQUIRE(items[2] == 'd');
+    REQUIRE(ids[2] == d);
 
     REQUIRE(triplets.size() == set.size());
+    REQUIRE(items.size() == set.size());
+    REQUIRE(ids.size() == set.size());
 }


### PR DESCRIPTION
* Let SparseSet::forall() callback only take T& and Id arguments
* Explicitly use std::vector as the internal container of ChannelData
* Add more unit tests for new forall routines