### PR TITLE
Implement hash function overloads for math structures

### DIFF
--- a/src/Math/Box2.hpp
+++ b/src/Math/Box2.hpp
@@ -153,3 +153,17 @@ namespace Dynamo {
         inline bool valid() const { return width() >= 0 && height() >= 0; }
     };
 } // namespace Dynamo
+
+/**
+ * @brief Hash function implementation for Box2
+ *
+ * @tparam
+ */
+template <>
+struct std::hash<Dynamo::Box2> {
+    inline size_t operator()(const Dynamo::Box2 &box) const {
+        size_t tmin = std::hash<Dynamo::Vec2>{}(box.min);
+        size_t tmax = std::hash<Dynamo::Vec2>{}(box.max);
+        return tmin ^ (tmax << 1);
+    }
+};

--- a/src/Math/Circle.hpp
+++ b/src/Math/Circle.hpp
@@ -110,3 +110,17 @@ namespace Dynamo {
         inline bool valid() const { return radius >= 0; }
     };
 } // namespace Dynamo
+
+/**
+ * @brief Hash function implementation for Circle
+ *
+ * @tparam
+ */
+template <>
+struct std::hash<Dynamo::Circle> {
+    inline size_t operator()(const Dynamo::Circle &circle) const {
+        size_t tcenter = std::hash<Dynamo::Vec2>{}(circle.center);
+        size_t tradius = std::hash<float>{}(circle.radius);
+        return tcenter ^ (tradius << 1);
+    }
+};

--- a/src/Math/Complex.hpp
+++ b/src/Math/Complex.hpp
@@ -231,3 +231,17 @@ namespace Dynamo {
         }
     };
 } // namespace Dynamo
+
+/**
+ * @brief Hash function implementation for Complex
+ *
+ * @tparam
+ */
+template <>
+struct std::hash<Dynamo::Complex> {
+    inline size_t operator()(const Dynamo::Complex &complex) const {
+        long tre = complex.re * 73856093;
+        long tim = complex.im * 19349663;
+        return tre ^ tim;
+    }
+};

--- a/src/Math/Quaternion.hpp
+++ b/src/Math/Quaternion.hpp
@@ -293,3 +293,19 @@ namespace Dynamo {
         }
     };
 } // namespace Dynamo
+
+/**
+ * @brief Hash function implementation for Quaternion
+ *
+ * @tparam
+ */
+template <>
+struct std::hash<Dynamo::Quaternion> {
+    inline size_t operator()(const Dynamo::Quaternion &quaternion) const {
+        long tx = quaternion.x * 73856093;
+        long ty = quaternion.y * 19349663;
+        long tz = quaternion.z * 83492791;
+        long tw = quaternion.w * 52477425;
+        return tx ^ ty ^ tz ^ tw;
+    }
+};

--- a/src/Math/Triangle2.hpp
+++ b/src/Math/Triangle2.hpp
@@ -103,3 +103,18 @@ namespace Dynamo {
         }
     };
 } // namespace Dynamo
+
+/**
+ * @brief Hash function implementation for Triangle2
+ *
+ * @tparam
+ */
+template <>
+struct std::hash<Dynamo::Triangle2> {
+    inline size_t operator()(const Dynamo::Triangle2 &triangle) const {
+        size_t ta = std::hash<Dynamo::Vec2>{}(triangle.a);
+        size_t tb = std::hash<Dynamo::Vec2>{}(triangle.b);
+        size_t tc = std::hash<Dynamo::Vec2>{}(triangle.c);
+        return ta ^ (tb << 1) ^ (tc << 2);
+    }
+};

--- a/src/Math/Vec2.hpp
+++ b/src/Math/Vec2.hpp
@@ -6,7 +6,7 @@
 
 namespace Dynamo {
     /**
-     * @brief Vector in 2-dimensions
+     * @brief 2D vector
      *
      */
     struct Vec2 {
@@ -207,3 +207,17 @@ namespace Dynamo {
         }
     };
 } // namespace Dynamo
+
+/**
+ * @brief Hash function implementation for Vec2
+ *
+ * @tparam
+ */
+template <>
+struct std::hash<Dynamo::Vec2> {
+    inline size_t operator()(const Dynamo::Vec2 &point) const {
+        long tx = point.x * 73856093;
+        long ty = point.y * 19349663;
+        return tx ^ ty;
+    }
+};

--- a/src/Math/Vec3.hpp
+++ b/src/Math/Vec3.hpp
@@ -6,7 +6,7 @@
 
 namespace Dynamo {
     /**
-     * @brief Vector in 3-dimensions
+     * @brief 3D vector
      *
      */
     struct Vec3 {
@@ -202,3 +202,18 @@ namespace Dynamo {
         }
     };
 } // namespace Dynamo
+
+/**
+ * @brief Hash function implementation for Vec3
+ *
+ * @tparam
+ */
+template <>
+struct std::hash<Dynamo::Vec3> {
+    inline size_t operator()(const Dynamo::Vec3 &point) const {
+        long tx = point.x * 73856093;
+        long ty = point.y * 19349663;
+        long tz = point.z * 83492791;
+        return tx ^ ty ^ tz;
+    }
+};

--- a/tests/Box2-Test.cpp
+++ b/tests/Box2-Test.cpp
@@ -206,3 +206,7 @@ TEST_CASE("Box2 invalid y", "[Box2]") {
     Dynamo::Box2 a({0, 5}, {2, 4});
     REQUIRE(!a.valid());
 }
+
+TEST_CASE("Box2 hash", "[Box2]") {
+    REQUIRE_NOTHROW(std::unordered_set<Dynamo::Box2>());
+}

--- a/tests/Circle-Test.cpp
+++ b/tests/Circle-Test.cpp
@@ -87,3 +87,7 @@ TEST_CASE("Circle invalid", "[Circle]") {
     Dynamo::Circle a({3, 0}, -1);
     REQUIRE(!a.valid());
 }
+
+TEST_CASE("Circle hash", "[Circle]") {
+    REQUIRE_NOTHROW(std::unordered_set<Dynamo::Circle>());
+}

--- a/tests/Complex-Test.cpp
+++ b/tests/Complex-Test.cpp
@@ -156,3 +156,7 @@ TEST_CASE("Complex number inequality", "[Complex]") {
     REQUIRE(a != c);
     REQUIRE(a != d);
 }
+
+TEST_CASE("Complex number hash", "[Complex]") {
+    REQUIRE_NOTHROW(std::unordered_set<Dynamo::Complex>());
+}

--- a/tests/Quaternion-Test.cpp
+++ b/tests/Quaternion-Test.cpp
@@ -211,3 +211,7 @@ TEST_CASE("Quaternion inequality", "[Quaternion]") {
     REQUIRE(a != c);
     REQUIRE(a != d);
 }
+
+TEST_CASE("Quaternion hash", "[Quaternion]") {
+    REQUIRE_NOTHROW(std::unordered_set<Dynamo::Quaternion>());
+}

--- a/tests/Triangle2-Test.cpp
+++ b/tests/Triangle2-Test.cpp
@@ -3,7 +3,7 @@
 
 #include "Common.hpp"
 
-TEST_CASE("Triangle circumcircle", "[Triangle]") {
+TEST_CASE("Triangle2 circumcircle", "[Triangle2]") {
     Dynamo::Vec2 a(8, 5);
     Dynamo::Vec2 b(5, 5);
     Dynamo::Vec2 c(5, 9);
@@ -16,7 +16,7 @@ TEST_CASE("Triangle circumcircle", "[Triangle]") {
     REQUIRE_THAT(circle.radius, Approx(2.5));
 }
 
-TEST_CASE("Triangle barycentric inside", "[Triangle]") {
+TEST_CASE("Triangle2 barycentric inside", "[Triangle2]") {
     Dynamo::Vec2 point(0, 0);
     Dynamo::Vec2 a(-1, -0.5);
     Dynamo::Vec2 b(1, -0.5);
@@ -29,7 +29,7 @@ TEST_CASE("Triangle barycentric inside", "[Triangle]") {
     REQUIRE_THAT(comb.y, Approx(point.y));
 }
 
-TEST_CASE("Triangle barycentric outside", "[Triangle]") {
+TEST_CASE("Triangle2 barycentric outside", "[Triangle2]") {
     Dynamo::Vec2 point(-2, 1);
     Dynamo::Vec2 a(-1, -0.5);
     Dynamo::Vec2 b(1, -0.5);
@@ -42,7 +42,7 @@ TEST_CASE("Triangle barycentric outside", "[Triangle]") {
     REQUIRE_THAT(comb.y, Approx(point.y));
 }
 
-TEST_CASE("Triangle barycentric on vertex", "[Triangle]") {
+TEST_CASE("Triangle2 barycentric on vertex", "[Triangle2]") {
     Dynamo::Vec2 point(-1, -0.5);
     Dynamo::Vec2 a(-1, -0.5);
     Dynamo::Vec2 b(1, -0.5);
@@ -60,7 +60,7 @@ TEST_CASE("Triangle barycentric on vertex", "[Triangle]") {
     REQUIRE_THAT(coords.z, Approx(0));
 }
 
-TEST_CASE("Triangle winding clockwise", "[Triangle]") {
+TEST_CASE("Triangle2 winding clockwise", "[Triangle2]") {
     Dynamo::Vec2 a(0, 0);
     Dynamo::Vec2 b(0, 1);
     Dynamo::Vec2 c(1, 0);
@@ -68,7 +68,7 @@ TEST_CASE("Triangle winding clockwise", "[Triangle]") {
     REQUIRE(triangle.winding() < 0);
 }
 
-TEST_CASE("Triangle winding collinear", "[Triangle]") {
+TEST_CASE("Triangle2 winding collinear", "[Triangle2]") {
     Dynamo::Vec2 a(0, 0);
     Dynamo::Vec2 b(0, 1);
     Dynamo::Vec2 c(0, 2);
@@ -76,7 +76,7 @@ TEST_CASE("Triangle winding collinear", "[Triangle]") {
     REQUIRE(triangle.winding() == 0);
 }
 
-TEST_CASE("Triangle winding anti-clockwise", "[Triangle]") {
+TEST_CASE("Triangle2 winding anti-clockwise", "[Triangle2]") {
     Dynamo::Vec2 a(0, 0);
     Dynamo::Vec2 b(1, 0);
     Dynamo::Vec2 c(0, 1);
@@ -84,7 +84,7 @@ TEST_CASE("Triangle winding anti-clockwise", "[Triangle]") {
     REQUIRE(triangle.winding() > 0);
 }
 
-TEST_CASE("Triangle equality", "[Triangle]") {
+TEST_CASE("Triangle2 equality", "[Triangle2]") {
     Dynamo::Vec2 a(0, 0);
     Dynamo::Vec2 b(1, 0);
     Dynamo::Vec2 c(0, 1);
@@ -95,7 +95,7 @@ TEST_CASE("Triangle equality", "[Triangle]") {
     REQUIRE(triangle1 == triangle2);
 }
 
-TEST_CASE("Triangle inequality", "[Triangle]") {
+TEST_CASE("Triangle2 inequality", "[Triangle2]") {
     Dynamo::Vec2 a(0, 0);
     Dynamo::Vec2 b(1, 0);
     Dynamo::Vec2 c(0, 1);
@@ -104,4 +104,8 @@ TEST_CASE("Triangle inequality", "[Triangle]") {
     Dynamo::Triangle2 triangle2(c, a, b);
 
     REQUIRE(triangle1 != triangle2);
+}
+
+TEST_CASE("Triangle2 hash", "[Triangle2]") {
+    REQUIRE_NOTHROW(std::unordered_set<Dynamo::Triangle2>());
 }

--- a/tests/Vec2-Test.cpp
+++ b/tests/Vec2-Test.cpp
@@ -136,3 +136,7 @@ TEST_CASE("Vec2 inequality", "[Vec2]") {
     REQUIRE(a != c);
     REQUIRE(a != d);
 }
+
+TEST_CASE("Vec2 hash", "[Vec2]") {
+    REQUIRE_NOTHROW(std::unordered_set<Dynamo::Vec2>());
+}

--- a/tests/Vec3-Test.cpp
+++ b/tests/Vec3-Test.cpp
@@ -135,3 +135,7 @@ TEST_CASE("Vec3 inequality", "[Vec3]") {
     REQUIRE(a != c);
     REQUIRE(a != d);
 }
+
+TEST_CASE("Vec3 hash", "[Vec3]") {
+    REQUIRE_NOTHROW(std::unordered_set<Dynamo::Vec3>());
+}


### PR DESCRIPTION
Implement hash functions for math structures like Vec2, Vec3, Quaternion, and even geometric objects like Triangle2. This allows me to implement algorithms that require sets of these objects, or to use them as keys in a hashtable.