### PR TITLE
Implement Engine::get_jukebox() to grab a reference to the audio engine

### DIFF
--- a/src/Engine/Engine.cpp
+++ b/src/Engine/Engine.cpp
@@ -28,6 +28,8 @@ namespace Dynamo {
 
     Core Engine::get_core() { return {*_display, *_input, *_clock}; }
 
+    Jukebox &Engine::get_jukebox() { return *_jukebox; }
+
     bool Engine::is_running() { return !_display->is_closed(); }
 
     void Engine::run() {

--- a/src/Engine/Engine.hpp
+++ b/src/Engine/Engine.hpp
@@ -56,6 +56,13 @@ namespace Dynamo {
         Core get_core();
 
         /**
+         * @brief Get a reference to Jukebox
+         *
+         * @return Jukebox&
+         */
+        Jukebox &get_jukebox();
+
+        /**
          * @brief Is the application still running?
          *
          * @return true

--- a/src/Engine/EngineFlag.hpp
+++ b/src/Engine/EngineFlag.hpp
@@ -5,7 +5,7 @@ namespace Dynamo {
      * @brief Customizable flags for initializing the engine
      *
      */
-    enum class EngineFlag {
+    enum class EngineFlag : unsigned {
         /**
          * @brief None
          *
@@ -25,17 +25,38 @@ namespace Dynamo {
         VSync = 1 << 1
     };
 
+    /**
+     * @brief AND operator
+     *
+     * @param lhs
+     * @param rhs
+     * @return unsigned
+     */
     inline unsigned operator&(EngineFlag lhs, EngineFlag rhs) {
         using T = unsigned;
         return static_cast<T>(lhs) & static_cast<T>(rhs);
     }
 
+    /**
+     * @brief OR operator
+     *
+     * @param lhs
+     * @param rhs
+     * @return EngineFlag
+     */
     inline EngineFlag operator|(EngineFlag lhs, EngineFlag rhs) {
         using T = unsigned;
         return static_cast<EngineFlag>(static_cast<T>(lhs) |
                                        static_cast<T>(rhs));
     }
 
+    /**
+     * @brief OR operator in-place
+     *
+     * @param lhs
+     * @param rhs
+     * @return EngineFlag
+     */
     inline EngineFlag operator|=(EngineFlag &lhs, EngineFlag rhs) {
         lhs = lhs | rhs;
         return lhs;

--- a/src/Jukebox/Sound.hpp
+++ b/src/Jukebox/Sound.hpp
@@ -118,6 +118,12 @@ namespace Dynamo {
     constexpr double DEFAULT_SAMPLE_RATE = 44100;
 
     /**
+     * @brief Sample normalization multiplier
+     *
+     */
+    constexpr double SAMPLE_NORM = 1.0 / __INT16_MAX__;
+
+    /**
      * @brief Sound asset represented as a signal holding multiple channels of
      * WaveSample data
      *
@@ -177,8 +183,7 @@ namespace Dynamo {
      * @return double
      */
     inline double norm_sample(const WaveSample sample) {
-        constexpr double scale = 1.0 / __INT16_MAX__;
-        return sample * scale;
+        return sample * SAMPLE_NORM;
     }
 
     /**


### PR DESCRIPTION
* Make EngineFlag enum use unsigned as the underlying type
* Factor out the WaveSample normalization constant