### PR TITLE
Use floats for all real-time audio calculations

### DIFF
--- a/src/Jukebox/Chunk.hpp
+++ b/src/Jukebox/Chunk.hpp
@@ -43,6 +43,6 @@ namespace Dynamo {
          * @brief Frame offset of the chunk
          *
          */
-        double frame;
+        float frame;
     };
 } // namespace Dynamo

--- a/src/Jukebox/Filters/Binaural.cpp
+++ b/src/Jukebox/Filters/Binaural.cpp
@@ -2,7 +2,7 @@
 
 namespace Dynamo {
     Binaural::Binaural(HRTF &hrtf) : _hrtf(hrtf) {
-        _coeffs.resize(_hrtf.get_filter_length(), 2);
+        _impulse_response.resize(_hrtf.get_length(), 2);
         _output.set_channels(2);
     }
 
@@ -12,16 +12,16 @@ namespace Dynamo {
                            const DynamicSoundMaterial &material,
                            const ListenerProperties &listener) {
         _output.set_frames(length);
-        _hrtf.get_coefficients(listener.position,
-                               listener.rotation,
-                               material.position,
-                               _coeffs);
+        _hrtf.get_impulse_response(listener.position,
+                                   listener.rotation,
+                                   material.position,
+                                   _impulse_response);
         for (int c = 0; c < 2; c++) {
             _convolvers[c].compute(src[c] + src_offset,
                                    _output[c],
-                                   _coeffs[c],
+                                   _impulse_response[c],
                                    length,
-                                   _coeffs.frames());
+                                   _impulse_response.frames());
         }
         return _output;
     }

--- a/src/Jukebox/Filters/Binaural.hpp
+++ b/src/Jukebox/Filters/Binaural.hpp
@@ -19,10 +19,10 @@ namespace Dynamo {
         HRTF &_hrtf;
 
         /**
-         * @brief Impulse response coefficients
+         * @brief Impulse response container
          *
          */
-        ChannelData<Complex> _coeffs;
+        Sound _impulse_response;
 
         /**
          * @brief Signal convolvers

--- a/src/Jukebox/Filters/Convolver.hpp
+++ b/src/Jukebox/Filters/Convolver.hpp
@@ -23,7 +23,7 @@ namespace Dynamo {
          *
          */
         std::vector<Complex> _fft_samples;
-        std::vector<Complex> _fft_coeffs;
+        std::vector<Complex> _fft_ir;
 
         /**
          * @brief Input buffer
@@ -48,16 +48,16 @@ namespace Dynamo {
         /**
          * @brief Apply the impulse repsonse to a sound
          *
-         * @param src    Source sound buffer
-         * @param dst    Destination sound buffer
-         * @param coeffs Impulse response coefficient buffer
-         * @param N      Length of the sound to be processed
-         * @param M      Length of the impulse response buffer
+         * @param src Source sound buffer
+         * @param dst Destination sound buffer
+         * @param ir  Impulse response buffer
+         * @param N   Length of the sound to be processed
+         * @param M   Length of the impulse response buffer
          * @return Sound&
          */
         void compute(WaveSample *src,
                      WaveSample *dst,
-                     Complex *coeffs,
+                     WaveSample *ir,
                      const unsigned N,
                      const unsigned M);
     };

--- a/src/Jukebox/Filters/Stereo.cpp
+++ b/src/Jukebox/Filters/Stereo.cpp
@@ -12,22 +12,22 @@ namespace Dynamo {
         Vec3 up = listener.rotation.up();
         Vec3 right = listener.rotation.right();
         Vec3 displacement = (delta - up * (delta * up));
-        double distance = displacement.length();
+        float distance = displacement.length();
 
         // Assume that if the distance is 0, the sound is centered
-        double pan = 0.5;
+        float pan = 0.5;
         if (distance > 0) {
             Vec3 direction = displacement / distance;
             pan = ((direction * right) + 1) * 0.5;
         }
 
         // Square-law panning
-        double l_gain = std::sqrt(1 - pan);
-        double r_gain = std::sqrt(pan);
+        float l_gain = std::sqrt(1 - pan);
+        float r_gain = std::sqrt(pan);
 
         _output.set_frames(length);
         for (unsigned c = 0; c < 2; c++) {
-            double gain = c == 0 ? l_gain : r_gain;
+            float gain = c == 0 ? l_gain : r_gain;
             for (unsigned f = 0; f < length; f++) {
                 _output[c][f] = src[c][f + src_offset] * gain;
             }

--- a/src/Jukebox/HRTF.hpp
+++ b/src/Jukebox/HRTF.hpp
@@ -23,10 +23,10 @@ namespace Dynamo {
      */
     class HRTF {
         /**
-         * @brief Maps azimuth-elevation angle pairs to coefficient sets
+         * @brief Maps azimuth-elevation angle pairs to impulse responses
          *
          */
-        std::unordered_map<Vec2, ChannelData<float>> _coeffs;
+        std::unordered_map<Vec2, Sound> _impulse_responses;
 
         /**
          * @brief Triangle mesh
@@ -35,10 +35,10 @@ namespace Dynamo {
         std::vector<Triangle2> _triangles;
 
         /**
-         * @brief Length of the filter
+         * @brief Length of the impulse response
          *
          */
-        unsigned _filter_length;
+        unsigned _length;
 
       public:
         /**
@@ -49,14 +49,14 @@ namespace Dynamo {
         HRTF(std::string filename);
 
         /**
-         * @brief Get the length of the filter coefficient buffer
+         * @brief Get the length of the impulse response
          *
          * @return unsigned
          */
-        unsigned get_filter_length();
+        unsigned get_length();
 
         /**
-         * @brief Get the Filter coefficients for a source relative to the
+         * @brief Get the impulse response for a source relative to the
          * listener, applying interpolation as needed
          *
          * @param listener_position Position of the listener
@@ -64,9 +64,9 @@ namespace Dynamo {
          * @param source_position   Position of the sound source
          * @param dst_buffer        Destination buffer
          */
-        void get_coefficients(const Vec3 &listener_position,
-                              const Quaternion &listener_rotation,
-                              const Vec3 &source_position,
-                              ChannelData<Complex> &dst_buffer);
+        void get_impulse_response(const Vec3 &listener_position,
+                                  const Quaternion &listener_rotation,
+                                  const Vec3 &source_position,
+                                  Sound &dst_buffer);
     };
 } // namespace Dynamo

--- a/src/Jukebox/Jukebox.hpp
+++ b/src/Jukebox/Jukebox.hpp
@@ -53,13 +53,13 @@ namespace Dynamo {
          * @brief Global volume control
          *
          */
-        double _volume;
+        float _volume;
 
         /**
          * @brief Final waveform on which all active chunks are layered onto
          *
          */
-        Sound _composite;
+        WaveForm _composite;
 
         /**
          * @brief Set of all listeners
@@ -100,7 +100,7 @@ namespace Dynamo {
              * @brief Sampling rate of the buffer
              *
              */
-            double sample_rate;
+            float sample_rate;
         };
         State _input_state;
         State _output_state;
@@ -235,9 +235,9 @@ namespace Dynamo {
         /**
          * @brief Get the master volume
          *
-         * @return double
+         * @return float
          */
-        double get_volume();
+        float get_volume();
 
         /**
          * @brief Pause audio playback
@@ -256,7 +256,7 @@ namespace Dynamo {
          *
          * @param volume
          */
-        void set_volume(double volume);
+        void set_volume(float volume);
 
         /**
          * @brief Get the sound asset manager

--- a/src/Jukebox/Listener.hpp
+++ b/src/Jukebox/Listener.hpp
@@ -21,7 +21,7 @@ namespace Dynamo {
          * @brief Listener volume
          *
          */
-        double volume = 1.0;
+        float volume = 1.0;
 
         /**
          * @brief Position of the listener in 3D space

--- a/src/Jukebox/Resample.cpp
+++ b/src/Jukebox/Resample.cpp
@@ -3,40 +3,40 @@
 namespace Dynamo {
     void resample_signal(WaveSample *src,
                          WaveSample *dst,
-                         double time_offset,
-                         double src_length,
-                         double src_rate,
-                         double dst_rate) {
-        double factor = dst_rate / src_rate;
-        double scale = std::min(1.0, factor);
-        double time_increment = 1.0 / factor;
+                         float time_offset,
+                         float src_length,
+                         float src_rate,
+                         float dst_rate) {
+        float factor = dst_rate / src_rate;
+        float scale = std::min(1.0f, factor);
+        float time_increment = 1.0 / factor;
 
         unsigned dst_length = src_length * factor;
         unsigned filter_step = scale * FILTER_PRECISION;
 
-        double time = time_offset;
-        double time_end = src_length + time_offset;
+        float time = time_offset;
+        float time_end = src_length + time_offset;
 
         for (unsigned dst_f = 0; dst_f < dst_length; dst_f++) {
             // Target sample
-            double dst_sample = 0;
+            float dst_sample = 0;
 
             // Get the source frame
             unsigned src_f = time;
-            double P = scale * (time - src_f);
+            float P = scale * (time - src_f);
 
             // Calculate filter offset and interpolation factor
-            double P_frac = P * FILTER_PRECISION;
+            float P_frac = P * FILTER_PRECISION;
             unsigned l = P_frac;
-            double interp = P_frac - l;
+            float interp = P_frac - l;
 
             // Left wing
             for (int i = 0; i < FILTER_HALF_LENGTH; i++) {
                 int s_i = src_f - i;
                 int h_i = l + i * filter_step;
                 if (s_i < 0 || h_i >= FILTER_HALF_LENGTH) break;
-                double weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
-                dst_sample += norm_sample(src[s_i]) * weight;
+                float weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
+                dst_sample += src[s_i] * weight;
             }
 
             // Invert
@@ -52,12 +52,12 @@ namespace Dynamo {
                 int s_i = src_f + i + 1;
                 int h_i = l + i * filter_step;
                 if (s_i >= time_end || h_i >= FILTER_HALF_LENGTH) break;
-                double weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
-                dst_sample += norm_sample(src[s_i]) * weight;
+                float weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
+                dst_sample += src[s_i] * weight;
             }
 
             // Set the new sample
-            dst[dst_f] = denorm_sample(dst_sample);
+            dst[dst_f] = dst_sample;
 
             // Increment time
             time += time_increment;

--- a/src/Jukebox/Resample.hpp
+++ b/src/Jukebox/Resample.hpp
@@ -130,8 +130,8 @@ namespace Dynamo {
      */
     void resample_signal(WaveSample *src,
                          WaveSample *dst,
-                         double time_offset,
-                         double src_length,
-                         double src_rate,
-                         double dst_rate);
+                         float time_offset,
+                         float src_length,
+                         float src_rate,
+                         float dst_rate);
 } // namespace Dynamo

--- a/src/Jukebox/Sound.cpp
+++ b/src/Jukebox/Sound.cpp
@@ -6,21 +6,21 @@ namespace Dynamo {
         WaveFrame output;
         output.channels = out_channels;
 
-        std::array<double, 2> norm = {0, 0};
+        std::array<float, 2> samples = {0, 0};
         for (unsigned src_c = 0; src_c < channels(); src_c++) {
-            double sample = norm_sample(at(frame, src_c));
+            WaveSample sample = at(frame, src_c);
 
             // Perform weighted sum using downmixing coefficient matrix
             int index = static_cast<int>(CHANNEL_ORDERS[channels() - 1][src_c]);
             for (unsigned dst_c = 0; dst_c < output.channels; dst_c++) {
-                double coeff = DOWNMIX_COEFFS[out_channels - 1][index][dst_c];
-                norm[dst_c] += sample * coeff;
+                float coeff = DOWNMIX_COEFFS[out_channels - 1][index][dst_c];
+                samples[dst_c] += sample * coeff;
             }
         }
 
         // Write denormalzed samples onto the output frame
-        for (int i = 0; i < norm.size(); i++) {
-            output.samples[i] = denorm_sample(norm[i]);
+        for (int i = 0; i < samples.size(); i++) {
+            output.samples[i] = samples[i];
         }
         return output;
     }

--- a/src/Jukebox/Sound.hpp
+++ b/src/Jukebox/Sound.hpp
@@ -11,10 +11,10 @@
 
 namespace Dynamo {
     /**
-     * @brief Indiviual sample ranges between [−32,767, +32,767]
+     * @brief Indiviual sample ranges between [−1.0, +1.0]
      *
      */
-    using WaveSample = short;
+    using WaveSample = float;
 
     /**
      * @brief An array of samples, a discrete representation of a sound wave
@@ -115,13 +115,7 @@ namespace Dynamo {
      * @brief The default sample rate is defined to be 44.1KHz
      *
      */
-    constexpr double DEFAULT_SAMPLE_RATE = 44100;
-
-    /**
-     * @brief Sample normalization multiplier
-     *
-     */
-    constexpr double SAMPLE_NORM = 1.0 / __INT16_MAX__;
+    constexpr float DEFAULT_SAMPLE_RATE = 44100;
 
     /**
      * @brief Sound asset represented as a signal holding multiple channels of
@@ -129,7 +123,7 @@ namespace Dynamo {
      *
      */
     class Sound : public ChannelData<WaveSample> {
-        double _sample_rate;
+        float _sample_rate;
 
       public:
         /**
@@ -141,7 +135,7 @@ namespace Dynamo {
          */
         Sound(unsigned frames = 0,
               unsigned channels = 0,
-              double sample_rate = DEFAULT_SAMPLE_RATE) :
+              float sample_rate = DEFAULT_SAMPLE_RATE) :
             ChannelData<WaveSample>(frames, channels),
             _sample_rate(sample_rate) {}
 
@@ -154,16 +148,16 @@ namespace Dynamo {
          */
         Sound(std::vector<WaveSample> samples,
               unsigned channels,
-              double sample_rate) :
+              float sample_rate) :
             ChannelData<WaveSample>(samples, channels),
             _sample_rate(sample_rate) {}
 
         /**
          * @brief Get the sample rate of the signal
          *
-         * @return double
+         * @return float
          */
-        inline double sample_rate() const { return _sample_rate; }
+        inline float sample_rate() const { return _sample_rate; }
 
         /**
          * @brief Grab a frame in the waveform and upmix or downmix to the
@@ -175,24 +169,4 @@ namespace Dynamo {
          */
         WaveFrame get_frame(const unsigned frame, const unsigned out_channels);
     };
-
-    /**
-     * @brief Normalize a wave sample
-     *
-     * @param sample Native sample format representation
-     * @return double
-     */
-    inline double norm_sample(const WaveSample sample) {
-        return sample * SAMPLE_NORM;
-    }
-
-    /**
-     * @brief Clip and denormalize a wave sample
-     *
-     * @param sample Normalized double representation
-     * @return WaveSample
-     */
-    inline WaveSample denorm_sample(const double sample) {
-        return std::clamp(sample, -1.0, 1.0) * __INT16_MAX__;
-    }
 } // namespace Dynamo

--- a/src/Jukebox/SoundDevice.hpp
+++ b/src/Jukebox/SoundDevice.hpp
@@ -36,6 +36,6 @@ namespace Dynamo {
          * @brief Compatible sample rate
          *
          */
-        double sample_rate;
+        float sample_rate;
     };
 } // namespace Dynamo

--- a/src/Jukebox/SoundManager.cpp
+++ b/src/Jukebox/SoundManager.cpp
@@ -12,7 +12,7 @@ namespace Dynamo {
         unsigned sample_rate = file.samplerate();
 
         // Read the PCM data
-        std::vector<short> interleaved(frames * channels);
+        WaveForm interleaved(frames * channels);
         file.readf(interleaved.data(), interleaved.size());
 
         // De-interleave the data into the final waveform buffer
@@ -27,7 +27,7 @@ namespace Dynamo {
 
     Asset<Sound> SoundManager::load_raw(const WaveForm waveform,
                                         const unsigned channels,
-                                        const double sample_rate) {
+                                        const float sample_rate) {
         return allocate(waveform, channels, sample_rate);
     }
 } // namespace Dynamo

--- a/src/Jukebox/SoundManager.hpp
+++ b/src/Jukebox/SoundManager.hpp
@@ -37,6 +37,6 @@ namespace Dynamo {
          */
         Asset<Sound> load_raw(const WaveForm waveform,
                               const unsigned channels,
-                              const double sample_rate);
+                              const float sample_rate);
     };
 } // namespace Dynamo

--- a/src/Jukebox/SoundMaterial.hpp
+++ b/src/Jukebox/SoundMaterial.hpp
@@ -24,13 +24,13 @@ namespace Dynamo {
          * @brief Volume to be played relative to overall gain
          *
          */
-        double volume = 1.0;
+        float volume = 1.0;
 
         /**
          * @brief Start time in seconds
          *
          */
-        double start_seconds = 0.0;
+        float start_seconds = 0.0;
 
         /**
          * @brief Filter pipeline
@@ -48,13 +48,13 @@ namespace Dynamo {
          * @brief Volume to be played relative to overall gain
          *
          */
-        double volume = 1.0;
+        float volume = 1.0;
 
         /**
          * @brief Start time in seconds
          *
          */
-        double start_seconds = 0.0;
+        float start_seconds = 0.0;
 
         /**
          * @brief Position of the sound in 3D space

--- a/src/Math/Common.hpp
+++ b/src/Math/Common.hpp
@@ -23,7 +23,7 @@ namespace Dynamo {
      * @param deg
      * @return float
      */
-    inline double to_radians(float deg) {
+    inline float to_radians(float deg) {
         static const float factor = M_PI / 180.0;
         return deg * factor;
     }

--- a/src/Math/Complex.hpp
+++ b/src/Math/Complex.hpp
@@ -9,8 +9,8 @@ namespace Dynamo {
      *
      */
     struct Complex {
-        double re;
-        double im;
+        float re;
+        float im;
 
         /**
          * @brief Construct a new Complex object
@@ -18,21 +18,21 @@ namespace Dynamo {
          * @param re Real part
          * @param im Imaginary part
          */
-        constexpr Complex(double re = 0, double im = 0) : re(re), im(im) {}
+        constexpr Complex(float re = 0, float im = 0) : re(re), im(im) {}
 
         /**
          * @brief Calculate the square length
          *
-         * @return double
+         * @return float
          */
-        inline double length_squared() const { return re * re + im * im; }
+        inline float length_squared() const { return re * re + im * im; }
 
         /**
          * @brief Calculate the length
          *
-         * @return double
+         * @return float
          */
-        inline double length() const { return std::sqrt(length_squared()); }
+        inline float length() const { return std::sqrt(length_squared()); }
 
         /**
          * @brief Calculate the reciprocal of the complex number for use in
@@ -41,7 +41,7 @@ namespace Dynamo {
          * @return Complex
          */
         inline Complex reciprocal() const {
-            double scale = 1.0 / length_squared();
+            float scale = 1.0 / length_squared();
             return Complex(re * scale, -im * scale);
         }
 
@@ -63,7 +63,7 @@ namespace Dynamo {
          * @return Complex
          */
         inline Complex exp() const {
-            double scale = std::exp(re);
+            float scale = std::exp(re);
             return Complex(scale * std::cos(im), scale * std::sin(im));
         }
 
@@ -101,8 +101,8 @@ namespace Dynamo {
          * @return Complex
          */
         inline Complex operator*(const Complex &rhs) const {
-            double n_re = re * rhs.re - im * rhs.im;
-            double n_im = re * rhs.im + im * rhs.re;
+            float n_re = re * rhs.re - im * rhs.im;
+            float n_im = re * rhs.im + im * rhs.re;
             return Complex(n_re, n_im);
         }
 
@@ -112,7 +112,7 @@ namespace Dynamo {
          * @param scalar
          * @return Complex
          */
-        inline Complex operator*(double scalar) const {
+        inline Complex operator*(float scalar) const {
             return Complex(scalar * re, scalar * im);
         }
 
@@ -132,8 +132,8 @@ namespace Dynamo {
          * @param scalar
          * @return Complex
          */
-        inline Complex operator/(double scalar) const {
-            double inv = 1.0 / scalar;
+        inline Complex operator/(float scalar) const {
+            float inv = 1.0 / scalar;
             return *this * inv;
         }
 
@@ -168,8 +168,8 @@ namespace Dynamo {
          * @return Complex&
          */
         inline Complex &operator*=(const Complex &rhs) {
-            double n_re = re * rhs.re - im * rhs.im;
-            double n_im = re * rhs.im + im * rhs.re;
+            float n_re = re * rhs.re - im * rhs.im;
+            float n_im = re * rhs.im + im * rhs.re;
             re = n_re;
             im = n_im;
             return *this;
@@ -181,7 +181,7 @@ namespace Dynamo {
          * @param scalar
          * @return Complex&
          */
-        inline Complex &operator*=(double scalar) {
+        inline Complex &operator*=(float scalar) {
             re *= scalar;
             im *= scalar;
             return *this;
@@ -204,8 +204,8 @@ namespace Dynamo {
          * @param scalar
          * @return Complex&
          */
-        inline Complex &operator/=(double scalar) {
-            double inv = 1.0 / scalar;
+        inline Complex &operator/=(float scalar) {
+            float inv = 1.0 / scalar;
             return *this *= inv;
         }
 

--- a/src/Math/Fourier.cpp
+++ b/src/Math/Fourier.cpp
@@ -75,7 +75,7 @@ namespace Dynamo::Fourier {
         }
 
         // Normalize
-        double inv_N = 1.0 / N;
+        float inv_N = 1.0 / N;
         for (int f = 0; f < N; f++) {
             signal[f] *= inv_N;
         }

--- a/src/Math/Fourier.hpp
+++ b/src/Math/Fourier.hpp
@@ -17,7 +17,7 @@ namespace Dynamo::Fourier {
      */
     constexpr std::array<Complex, 32> construct_twiddle_table(bool inverse) {
         std::array<Complex, 32> table;
-        double sign = inverse ? 1 : -1;
+        float sign = inverse ? 1 : -1;
         for (unsigned i = 0; i < 32; i++) {
             table[i] = Complex(0, sign * 2 * M_PI / (1 << i)).exp();
         }

--- a/tests/src/Common.hpp
+++ b/tests/src/Common.hpp
@@ -9,5 +9,5 @@
  * @return Catch::Matchers::WithinAbsMatcher
  */
 Catch::Matchers::WithinAbsMatcher Approx(double x) {
-    return Catch::Matchers::WithinAbs(x, 1e-7);
+    return Catch::Matchers::WithinAbs(x, 1e-6);
 }

--- a/tests/src/Complex-Test.cpp
+++ b/tests/src/Complex-Test.cpp
@@ -17,15 +17,15 @@ TEST_CASE("Complex number length", "[Complex]") {
 TEST_CASE("Complex number reciprocal", "[Complex]") {
     Dynamo::Complex z(3, 4);
     Dynamo::Complex reciprocal = z.reciprocal();
-    REQUIRE(reciprocal.re == 3 / 25.0);
-    REQUIRE(reciprocal.im == -4 / 25.0);
+    REQUIRE(reciprocal.re == 3 / 25.0f);
+    REQUIRE(reciprocal.im == -4 / 25.0f);
 }
 
 TEST_CASE("Complex number conjugate", "[Complex]") {
     Dynamo::Complex z(3, 4);
     Dynamo::Complex conjugate = z.conjugate();
-    REQUIRE(conjugate.re == 3.0);
-    REQUIRE(conjugate.im == -4.0);
+    REQUIRE(conjugate.re == 3);
+    REQUIRE(conjugate.im == -4);
 }
 
 TEST_CASE("Complex number exp", "[Complex]") {
@@ -76,23 +76,23 @@ TEST_CASE("Complex number multiply", "[Complex]") {
 TEST_CASE("Complex number multiply scalar", "[Complex]") {
     Dynamo::Complex a(-1, 2);
     Dynamo::Complex c = a * 3.2;
-    REQUIRE(c.re == -3.2);
-    REQUIRE(c.im == 6.4);
+    REQUIRE(c.re == -3.2f);
+    REQUIRE(c.im == 6.4f);
 }
 
 TEST_CASE("Complex number divide", "[Complex]") {
     Dynamo::Complex a(-5, 10);
     Dynamo::Complex b(3, 4);
     Dynamo::Complex c = a / b;
-    REQUIRE(c.re == 1);
-    REQUIRE(c.im == 2);
+    REQUIRE_THAT(c.re, Approx(1.0f));
+    REQUIRE_THAT(c.im, Approx(2.0f));
 }
 
 TEST_CASE("Complex number divide scalar", "[Complex]") {
     Dynamo::Complex a(-3.2, 6.4);
     Dynamo::Complex c = a / 3.2;
-    REQUIRE(c.re == -1);
-    REQUIRE(c.im == 2);
+    REQUIRE(c.re == -1.0f);
+    REQUIRE(c.im == 2.0f);
 }
 
 TEST_CASE("Complex number add in-place", "[Complex]") {
@@ -122,23 +122,23 @@ TEST_CASE("Complex number multiply in-place", "[Complex]") {
 TEST_CASE("Complex number multiply scalar in-place", "[Complex]") {
     Dynamo::Complex a(-1, 2);
     a *= 3.2;
-    REQUIRE(a.re == -3.2);
-    REQUIRE(a.im == 6.4);
+    REQUIRE(a.re == -3.2f);
+    REQUIRE(a.im == 6.4f);
 }
 
 TEST_CASE("Complex number divide in-place", "[Complex]") {
     Dynamo::Complex a(-5, 10);
     Dynamo::Complex b(3, 4);
     a /= b;
-    REQUIRE(a.re == 1);
-    REQUIRE(a.im == 2);
+    REQUIRE_THAT(a.re, Approx(1.0f));
+    REQUIRE_THAT(a.im, Approx(2.0f));
 }
 
 TEST_CASE("Complex number divide scalar in-place", "[Complex]") {
     Dynamo::Complex a(-3.2, 6.4);
     a /= 3.2;
-    REQUIRE(a.re == -1);
-    REQUIRE(a.im == 2);
+    REQUIRE(a.re == -1.0f);
+    REQUIRE(a.im == 2.0f);
 }
 
 TEST_CASE("Complex number equality", "[Complex]") {


### PR DESCRIPTION
* Change internal member types for Complex numbers to float
* Update unit tests to account for floating point precision issues