### PR TITLE
Use double precision for audio resampling algorithm

### DIFF
--- a/src/Jukebox/Jukebox.cpp
+++ b/src/Jukebox/Jukebox.cpp
@@ -96,14 +96,14 @@ namespace Dynamo {
         StaticSoundMaterial &material = chunk.material.get();
 
         // Calculate the number of frames in the destination
-        float frame_stop = std::min(chunk.frame + CHUNK_LENGTH,
-                                    static_cast<float>(sound.frames()));
-        float frames = frame_stop - chunk.frame;
+        double frame_stop = std::min(chunk.frame + CHUNK_LENGTH,
+                                     static_cast<float>(sound.frames()));
+        double frames = frame_stop - chunk.frame;
 
         // Calculate the number of frames required in the original signal to
         // produce the destination frames
-        float factor = sound.sample_rate() / _output_state.sample_rate;
-        float length = frames * factor;
+        double factor = sound.sample_rate() / _output_state.sample_rate;
+        double length = frames * factor;
 
         // Resample the audio to the device sample rate
         Sound transformed(frames, _output_state.channels);
@@ -143,14 +143,14 @@ namespace Dynamo {
         DynamicSoundMaterial &material = chunk.material.get();
 
         // Calculate the number of frames in the destination
-        float frame_stop = std::min(chunk.frame + CHUNK_LENGTH,
-                                    static_cast<float>(sound.frames()));
-        float frames = frame_stop - chunk.frame;
+        double frame_stop = std::min(chunk.frame + CHUNK_LENGTH,
+                                     static_cast<float>(sound.frames()));
+        double frames = frame_stop - chunk.frame;
 
         // Calculate the number of frames required in the original signal to
         // produce the destination frames
-        float factor = sound.sample_rate() / _output_state.sample_rate;
-        float length = frames * factor;
+        double factor = sound.sample_rate() / _output_state.sample_rate;
+        double length = frames * factor;
 
         // Resample the audio to the device sample rate
         Sound transformed(frames, _output_state.channels);

--- a/src/Jukebox/Jukebox.hpp
+++ b/src/Jukebox/Jukebox.hpp
@@ -100,7 +100,7 @@ namespace Dynamo {
              * @brief Sampling rate of the buffer
              *
              */
-            float sample_rate;
+            double sample_rate;
         };
         State _input_state;
         State _output_state;

--- a/src/Jukebox/Resample.cpp
+++ b/src/Jukebox/Resample.cpp
@@ -3,39 +3,39 @@
 namespace Dynamo {
     void resample_signal(WaveSample *src,
                          WaveSample *dst,
-                         float time_offset,
-                         float src_length,
-                         float src_rate,
-                         float dst_rate) {
-        float factor = dst_rate / src_rate;
-        float scale = std::min(1.0f, factor);
-        float time_increment = 1.0 / factor;
+                         double time_offset,
+                         double src_length,
+                         double src_rate,
+                         double dst_rate) {
+        double factor = dst_rate / src_rate;
+        double scale = std::min(1.0, factor);
+        double time_increment = 1.0 / factor;
 
         unsigned dst_length = src_length * factor;
         unsigned filter_step = scale * FILTER_PRECISION;
 
-        float time = time_offset;
-        float time_end = src_length + time_offset;
+        double time = time_offset;
+        double time_end = src_length + time_offset;
 
         for (unsigned dst_f = 0; dst_f < dst_length; dst_f++) {
             // Target sample
-            float dst_sample = 0;
+            double dst_sample = 0;
 
             // Get the source frame
             unsigned src_f = time;
-            float P = scale * (time - src_f);
+            double P = scale * (time - src_f);
 
             // Calculate filter offset and interpolation factor
-            float P_frac = P * FILTER_PRECISION;
+            double P_frac = P * FILTER_PRECISION;
             unsigned l = P_frac;
-            float interp = P_frac - l;
+            double interp = P_frac - l;
 
             // Left wing
             for (int i = 0; i < FILTER_HALF_LENGTH; i++) {
                 int s_i = src_f - i;
                 int h_i = l + i * filter_step;
                 if (s_i < 0 || h_i >= FILTER_HALF_LENGTH) break;
-                float weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
+                double weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
                 dst_sample += src[s_i] * weight;
             }
 
@@ -52,7 +52,7 @@ namespace Dynamo {
                 int s_i = src_f + i + 1;
                 int h_i = l + i * filter_step;
                 if (s_i >= time_end || h_i >= FILTER_HALF_LENGTH) break;
-                float weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
+                double weight = FILTER_RWING[h_i] + interp * FILTER_DIFFS[h_i];
                 dst_sample += src[s_i] * weight;
             }
 

--- a/src/Jukebox/Resample.hpp
+++ b/src/Jukebox/Resample.hpp
@@ -130,8 +130,8 @@ namespace Dynamo {
      */
     void resample_signal(WaveSample *src,
                          WaveSample *dst,
-                         float time_offset,
-                         float src_length,
-                         float src_rate,
-                         float dst_rate);
+                         double time_offset,
+                         double src_length,
+                         double src_rate,
+                         double dst_rate);
 } // namespace Dynamo


### PR DESCRIPTION
Fix precision issue in the resampling procedure that causes noticable glitches (crackles) in audio playback.