### PR TITLE
Implement a wrapper class for a Vulkan Buffer

### DIFF
--- a/src/Dynamo.hpp
+++ b/src/Dynamo.hpp
@@ -30,6 +30,7 @@
 
 #include "Math/Box2.hpp"
 #include "Math/Circle.hpp"
+#include "Math/Color.hpp"
 #include "Math/Common.hpp"
 #include "Math/Complex.hpp"
 #include "Math/Delaunay.hpp"
@@ -41,8 +42,8 @@
 #include "Math/Triangle2.hpp"
 #include "Math/Vec2.hpp"
 #include "Math/Vec3.hpp"
-#include "Math/Color.hpp"
 
+#include "Utils/Allocator.hpp"
 #include "Utils/Bits.hpp"
 #include "Utils/ChannelData.hpp"
 #include "Utils/IdTracker.hpp"

--- a/src/Graphics/Vulkan/Buffer.cpp
+++ b/src/Graphics/Vulkan/Buffer.cpp
@@ -1,0 +1,173 @@
+#include "./Buffer.hpp"
+
+namespace Dynamo::Graphics::Vulkan {
+    Buffer::Buffer(Device &device,
+                   unsigned size,
+                   MemoryPool &memory_pool,
+                   CommandPool &command_pool,
+                   vk::Queue &transfer_queue,
+                   vk::BufferUsageFlags usage,
+                   vk::MemoryPropertyFlags properties) :
+        _handle(create_raw_buffer(device.get_handle(), size, usage)),
+        _device(device), _allocator(size),
+        _memory(memory_pool.allocate(get_memory_requirements(), properties)),
+        _memory_pool(memory_pool), _command_pool(command_pool) {
+        _usage = usage;
+        _properties = properties;
+
+        _transfer_queue = transfer_queue;
+        _command_buffer = std::move(
+            command_pool.allocate(vk::CommandBufferLevel::ePrimary, 1)[0]);
+
+        _memory.bind(_handle);
+    }
+
+    Buffer::Buffer(Device &device,
+                   MemoryPool &memory_pool,
+                   CommandPool &command_pool,
+                   vk::Queue &transfer_queue,
+                   vk::BufferUsageFlags usage,
+                   vk::MemoryPropertyFlags properties) :
+        Buffer(device,
+               DEFAULT_BUFFER_SIZE,
+               memory_pool,
+               command_pool,
+               transfer_queue,
+               usage,
+               properties) {}
+
+    Buffer::~Buffer() { _device.get().get_handle().destroyBuffer(_handle); }
+
+    vk::Buffer Buffer::create_raw_buffer(const vk::Device &device,
+                                         unsigned size,
+                                         vk::BufferUsageFlags usage) {
+        vk::BufferCreateInfo buffer_info;
+        buffer_info.size = size;
+        buffer_info.usage = usage | vk::BufferUsageFlagBits::eTransferDst |
+                            vk::BufferUsageFlagBits::eTransferSrc;
+
+        return device.createBuffer(buffer_info);
+    }
+
+    void Buffer::grow(unsigned size) {
+        // Allocate new memory and buffer
+        vk::Buffer new_handle =
+            create_raw_buffer(_device.get().get_handle(), size, _usage);
+        MemoryBlock new_memory = _memory_pool.get().allocate(
+            _device.get().get_handle().getBufferMemoryRequirements(new_handle),
+            _properties);
+        new_memory.bind(new_handle);
+
+        // Reset the command pool
+        _device.get().get_handle().resetCommandPool(
+            _command_pool.get().get_handle(),
+            vk::CommandPoolResetFlagBits::eReleaseResources);
+
+        // Perform the copy
+        vk::CommandBufferBeginInfo begin_info;
+        begin_info.flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit;
+        _command_buffer->begin(begin_info);
+
+        vk::BufferCopy copy_region;
+        copy_region.dstOffset = 0;
+        copy_region.srcOffset = 0;
+        copy_region.size = _allocator.capacity();
+        _command_buffer->copyBuffer(_handle, new_handle, copy_region);
+
+        _command_buffer->end();
+
+        // Submit the command to the transfer queue
+        vk::SubmitInfo submit_info;
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &_command_buffer.get();
+
+        _transfer_queue.submit(submit_info, nullptr);
+        _transfer_queue.waitIdle();
+
+        // Reassign
+        _device.get().get_handle().destroyBuffer(_handle);
+        _handle = new_handle;
+        _memory = std::move(new_memory);
+
+        // Update the allocator
+        _allocator.grow(size);
+    }
+
+    const vk::Buffer &Buffer::get_handle() const { return _handle; }
+
+    vk::MemoryRequirements Buffer::get_memory_requirements() const {
+        return _device.get().get_handle().getBufferMemoryRequirements(_handle);
+    }
+
+    unsigned Buffer::reserve(unsigned size, unsigned alignment) {
+        std::optional<unsigned> result = _allocator.reserve(size, alignment);
+        if (result.has_value()) {
+            return result.value();
+        } else {
+            unsigned current = _allocator.capacity();
+            grow(std::max(align_size(current + size, 2), current * 2));
+
+            // If this fails, we're in trouble...
+            return _allocator.reserve(size, alignment).value();
+        }
+    }
+
+    void Buffer::free(unsigned offset) { return _allocator.free(offset); }
+
+    void Buffer::write(char *src, unsigned offset, unsigned length) {
+        if (!_allocator.is_reserved(offset)) {
+            Log::error("Invalid Vulkan buffer offset write");
+        }
+        _memory.write(src, offset, length);
+    }
+
+    void Buffer::read(char *dst, unsigned offset, unsigned length) {
+        if (!_allocator.is_reserved(offset)) {
+            Log::error("Invalid Vulkan buffer offset read");
+        }
+        _memory.read(dst, offset, length);
+    }
+
+    unsigned Buffer::capacity() const { return _allocator.capacity(); }
+
+    unsigned Buffer::size(unsigned offset) const {
+        return _allocator.size(offset);
+    }
+
+    void Buffer::copy(Buffer &dst,
+                      unsigned src_offset,
+                      unsigned dst_offset,
+                      unsigned length) {
+        // Make sure there is enough space
+        if (length > dst.size(dst_offset)) {
+            Log::error("Attempted to copy Vulkan buffer contents to "
+                       "destination block with inadequate size.");
+        }
+
+        // Reset the command pool
+        _device.get().get_handle().resetCommandPool(
+            _command_pool.get().get_handle(),
+            vk::CommandPoolResetFlagBits::eReleaseResources);
+
+        // Perform the copy
+        vk::CommandBufferBeginInfo begin_info;
+        begin_info.flags = vk::CommandBufferUsageFlagBits::eOneTimeSubmit;
+        _command_buffer->begin(begin_info);
+
+        vk::BufferCopy copy_region;
+        copy_region.dstOffset = dst_offset;
+        copy_region.srcOffset = src_offset;
+        copy_region.size = length;
+        _command_buffer->copyBuffer(_handle, dst.get_handle(), copy_region);
+
+        _command_buffer->end();
+
+        // Submit the command to the transfer queue
+        vk::SubmitInfo submit_info;
+        submit_info.commandBufferCount = 1;
+        submit_info.pCommandBuffers = &_command_buffer.get();
+
+        _transfer_queue.submit(submit_info, nullptr);
+        _transfer_queue.waitIdle();
+    }
+} // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/Buffer.hpp
+++ b/src/Graphics/Vulkan/Buffer.hpp
@@ -1,0 +1,176 @@
+#pragma once
+
+#include <optional>
+
+#include <vulkan/vulkan.hpp>
+
+#include "../../Utils/Allocator.hpp"
+#include "./CommandPool.hpp"
+#include "./Device.hpp"
+#include "./MemoryPool.hpp"
+
+namespace Dynamo::Graphics::Vulkan {
+    /**
+     * @brief Initial size of a Vulkan buffer
+     *
+     */
+    constexpr unsigned DEFAULT_BUFFER_SIZE = (1 << 20);
+
+    /**
+     * @brief Wrapper class of Vulkan Buffer
+     *
+     */
+    class Buffer {
+        vk::Buffer _handle;
+        std::reference_wrapper<Device> _device;
+        Allocator _allocator;
+        MemoryBlock _memory;
+
+        std::reference_wrapper<MemoryPool> _memory_pool;
+        std::reference_wrapper<CommandPool> _command_pool;
+
+        vk::BufferUsageFlags _usage;
+        vk::MemoryPropertyFlags _properties;
+
+        vk::Queue _transfer_queue;
+        vk::UniqueCommandBuffer _command_buffer;
+
+        /**
+         * @brief Create a vk::Buffer handle
+         *
+         * @param device vk::Device handle
+         * @param size   Size of the buffer
+         * @param usage  Buffer usage flags
+         * @return vk::Buffer
+         */
+        static vk::Buffer create_raw_buffer(const vk::Device &device,
+                                            unsigned size,
+                                            vk::BufferUsageFlags usage);
+
+        /**
+         * @brief Grow the buffer
+         *
+         * @param size
+         */
+        void grow(unsigned size);
+
+      public:
+        /**
+         * @brief Construct a new Buffer object
+         *
+         * @param device         Reference to the logical device
+         * @param size           Initial size of the buffer
+         * @param memory_pool    Reference to the memory pool
+         * @param command_pool   Reference to the command pool
+         * @param transfer_queue Transfer command queue
+         * @param usage          Buffer usage flags
+         * @param properties     Underlying buffer memory propertes
+         */
+        Buffer(Device &device,
+               unsigned size,
+               MemoryPool &memory_pool,
+               CommandPool &command_pool,
+               vk::Queue &transfer_queue,
+               vk::BufferUsageFlags usage,
+               vk::MemoryPropertyFlags properties);
+
+        /**
+         * @brief Construct a new Buffer object
+         *
+         * @param device         Reference to the logical device
+         * @param memory_pool    Reference to the memory pool
+         * @param command_pool   Reference to the command pool
+         * @param transfer_queue Transfer command queue
+         * @param usage          Buffer usage flags
+         * @param properties     Underlying buffer memory propertes
+         */
+        Buffer(Device &device,
+               MemoryPool &memory_pool,
+               CommandPool &command_pool,
+               vk::Queue &transfer_queue,
+               vk::BufferUsageFlags usage,
+               vk::MemoryPropertyFlags properties);
+
+        /**
+         * @brief Destroy the Buffer object
+         *
+         */
+        ~Buffer();
+
+        /**
+         * @brief Get the handle to vk::Buffer
+         *
+         * @return const vk::Buffer&
+         */
+        const vk::Buffer &get_handle() const;
+
+        /**
+         * @brief Get the memory requirements for the buffer
+         *
+         * @return vk::MemoryRequirements
+         */
+        vk::MemoryRequirements get_memory_requirements() const;
+
+        /**
+         * @brief Reserve a block of memory with specific alignment
+         * requirements, returning the offset within the buffer.
+         *
+         * @param size      Desired size in bytes
+         * @param alignment Alignment requirement in bytes
+         * @return unsigned
+         */
+        unsigned reserve(unsigned size, unsigned alignment);
+
+        /**
+         * @brief Free the block of reserved memory at an offset
+         *
+         * @param offset Offset within the buffer in bytes returned by reserve()
+         */
+        void free(unsigned offset);
+
+        /**
+         * @brief Get the total capacity of the buffer
+         *
+         * @return unsigned
+         */
+        unsigned capacity() const;
+
+        /**
+         * @brief Get the size of a reserved memory block
+         *
+         * @param offset Offset within the buffer in bytes returned by reserve()
+         */
+        unsigned size(unsigned offset) const;
+
+        /**
+         * @brief Write to the underlying memory
+         *
+         * @param src    Source buffer
+         * @param offset Offset within the buffer in bytes returned by reserve()
+         * @param length Length of the write in bytes
+         */
+        void write(char *src, unsigned offset, unsigned length);
+
+        /**
+         * @brief Read from the underlying memory
+         *
+         * @param dst    Destination buffer
+         * @param offset Offset within the buffer in bytes returned by reserve()
+         * @param length Length of the read in bytes
+         */
+        void read(char *dst, unsigned offset, unsigned length);
+
+        /**
+         * @brief Copy the contents of a buffer block to another bufffer
+         *
+         * @param dst        Destination buffer
+         * @param src_offset Valid source offset
+         * @param dst_offset Valid destination offset
+         * @param length     Length of the copy <= destination block size
+         */
+        void copy(Buffer &dst,
+                  unsigned src_offset,
+                  unsigned dst_offset,
+                  unsigned length);
+    };
+} // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/CommandPool.cpp
+++ b/src/Graphics/Vulkan/CommandPool.cpp
@@ -13,9 +13,7 @@ namespace Dynamo::Graphics::Vulkan {
         _device.get().get_handle().destroyCommandPool(_handle);
     }
 
-    const vk::CommandPool &CommandPool::get_handle() const {
-        return _handle;
-    }
+    const vk::CommandPool &CommandPool::get_handle() const { return _handle; }
 
     QueueFamily CommandPool::get_family() const { return _family; }
 

--- a/src/Graphics/Vulkan/Image.cpp
+++ b/src/Graphics/Vulkan/Image.cpp
@@ -13,7 +13,7 @@ namespace Dynamo::Graphics::Vulkan {
                  vk::Format format,
                  vk::ImageType type,
                  vk::ImageTiling tiling,
-                 vk::Flags<vk::ImageUsageFlagBits> usage) :
+                 vk::ImageUsageFlags usage) :
         _device(device) {
         vk::ImageCreateInfo image_info;
         image_info.imageType = type;
@@ -41,7 +41,7 @@ namespace Dynamo::Graphics::Vulkan {
 
     vk::Format Image::get_format() { return _format; }
 
-    vk::MemoryRequirements Image::get_memory_requirements() {
+    vk::MemoryRequirements Image::get_memory_requirements() const {
         return _device.get().get_handle().getImageMemoryRequirements(_handle);
     }
 
@@ -55,7 +55,7 @@ namespace Dynamo::Graphics::Vulkan {
                          vk::Format format,
                          vk::ImageType type,
                          vk::ImageTiling tiling,
-                         vk::Flags<vk::ImageUsageFlagBits> usage) :
+                         vk::ImageUsageFlags usage) :
         Image(device,
               width,
               height,

--- a/src/Graphics/Vulkan/Image.hpp
+++ b/src/Graphics/Vulkan/Image.hpp
@@ -51,7 +51,7 @@ namespace Dynamo::Graphics::Vulkan {
               vk::Format format,
               vk::ImageType type,
               vk::ImageTiling tiling,
-              vk::Flags<vk::ImageUsageFlagBits> usage);
+              vk::ImageUsageFlags usage);
         virtual ~Image() = 0;
 
         /**
@@ -80,7 +80,7 @@ namespace Dynamo::Graphics::Vulkan {
          *
          * @return vk::MemoryRequirements
          */
-        vk::MemoryRequirements get_memory_requirements();
+        vk::MemoryRequirements get_memory_requirements() const;
     };
     inline Image::~Image() = default;
 
@@ -117,7 +117,7 @@ namespace Dynamo::Graphics::Vulkan {
                   vk::Format format,
                   vk::ImageType type,
                   vk::ImageTiling tiling,
-                  vk::Flags<vk::ImageUsageFlagBits> usage);
+                  vk::ImageUsageFlags usage);
 
         /**
          * @brief Destroy the UserImage object

--- a/src/Graphics/Vulkan/Memory.cpp
+++ b/src/Graphics/Vulkan/Memory.cpp
@@ -3,7 +3,7 @@
 namespace Dynamo::Graphics::Vulkan {
     Memory::Memory(Device &device,
                    vk::MemoryRequirements requirements,
-                   vk::MemoryPropertyFlagBits properties) :
+                   vk::MemoryPropertyFlags properties) :
         _device(device),
         _allocator(requirements.size) {
         // Find the appropriate type index

--- a/src/Graphics/Vulkan/Memory.hpp
+++ b/src/Graphics/Vulkan/Memory.hpp
@@ -7,7 +7,7 @@
 #include <vulkan/vulkan.hpp>
 
 #include "../../Log/Log.hpp"
-#include "./Allocator.hpp"
+#include "../../Utils/Allocator.hpp"
 #include "./Device.hpp"
 
 namespace Dynamo::Graphics::Vulkan {
@@ -35,7 +35,7 @@ namespace Dynamo::Graphics::Vulkan {
          */
         Memory(Device &device,
                vk::MemoryRequirements requirements,
-               vk::MemoryPropertyFlagBits properties);
+               vk::MemoryPropertyFlags properties);
 
         /**
          * @brief Destroy the Memory object

--- a/src/Graphics/Vulkan/MemoryPool.hpp
+++ b/src/Graphics/Vulkan/MemoryPool.hpp
@@ -19,27 +19,16 @@ namespace Dynamo::Graphics::Vulkan {
 
     /**
      * @brief MemoryBlock exposes a similar interface to Memory for managing an
-     * underlying block of memory at an offset
+     * underlying block of memory at an offset, but is similar to
+     * std::unique_ptr in that it can only be moved and not copied
      *
      */
     class MemoryBlock {
-        /**
-         * @brief Reference to the memory
-         *
-         */
         std::reference_wrapper<Memory> _memory;
-
-        /**
-         * @brief Reserved offset within the memory
-         *
-         */
         unsigned _offset;
-
-        /**
-         * @brief Size of the reserveed block
-         *
-         */
         unsigned _size;
+
+        bool _moved;
 
       public:
         /**
@@ -57,13 +46,6 @@ namespace Dynamo::Graphics::Vulkan {
          * @param rhs
          */
         MemoryBlock(MemoryBlock &&rhs);
-
-        /**
-         * @brief Copy constructor
-         *
-         * @param rhs
-         */
-        MemoryBlock(MemoryBlock &rhs) = delete;
 
         /**
          * @brief Destroy the MemoryBlock object
@@ -123,6 +105,13 @@ namespace Dynamo::Graphics::Vulkan {
          * @param vkbuffer
          */
         void bind(vk::Buffer vkbuffer);
+
+        /**
+         * @brief Move assignment operator
+         *
+         * @param rhs
+         */
+        void operator=(MemoryBlock &&rhs);
     };
 
     /**
@@ -150,7 +139,7 @@ namespace Dynamo::Graphics::Vulkan {
          */
         bool is_compatible(Memory &memory,
                            vk::MemoryRequirements requirements,
-                           vk::MemoryPropertyFlagBits properties);
+                           vk::MemoryPropertyFlags properties);
 
       public:
         /**
@@ -169,6 +158,6 @@ namespace Dynamo::Graphics::Vulkan {
          * @return Allocation
          */
         MemoryBlock allocate(vk::MemoryRequirements requirements,
-                             vk::MemoryPropertyFlagBits properties);
+                             vk::MemoryPropertyFlags properties);
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/Renderer.cpp
+++ b/src/Graphics/Vulkan/Renderer.cpp
@@ -19,6 +19,8 @@ namespace Dynamo::Graphics::Vulkan {
         create_pipeline();
         create_command_buffers();
 
+        create_buffers();
+
         clear(Color(0, 0, 0));
         _depth_clear.depthStencil.depth = 1;
         _depth_clear.depthStencil.stencil = 0;
@@ -280,6 +282,49 @@ namespace Dynamo::Graphics::Vulkan {
         _transfer_command_buffers =
             _graphics_command_pool->allocate(vk::CommandBufferLevel::ePrimary,
                                              1);
+    }
+
+    void Renderer::create_buffers() {
+        // Staging buffer for memory copies
+        vk::MemoryPropertyFlags staging_memory_properties =
+            vk::MemoryPropertyFlagBits::eHostVisible |
+            vk::MemoryPropertyFlagBits::eHostCoherent |
+            vk::MemoryPropertyFlagBits::eHostCached;
+        vk::BufferUsageFlags staging_buffer_usage =
+            vk::BufferUsageFlagBits::eTransferSrc;
+        _staging_buffer = std::make_unique<Buffer>(*_device,
+                                                   *_memory_pool,
+                                                   *_transfer_command_pool,
+                                                   _transfer_queue,
+                                                   staging_buffer_usage,
+                                                   staging_memory_properties);
+
+        // Object mesh buffer
+        vk::MemoryPropertyFlags object_memory_properties =
+            vk::MemoryPropertyFlagBits::eDeviceLocal;
+        vk::BufferUsageFlags object_buffer_usage =
+            vk::BufferUsageFlagBits::eIndexBuffer |
+            vk::BufferUsageFlagBits::eVertexBuffer;
+        _object_buffer = std::make_unique<Buffer>(*_device,
+                                                  *_memory_pool,
+                                                  *_transfer_command_pool,
+                                                  _transfer_queue,
+                                                  object_buffer_usage,
+                                                  object_memory_properties);
+
+        // Uniform buffer
+        vk::MemoryPropertyFlags uniform_memory_properties =
+            vk::MemoryPropertyFlagBits::eHostVisible |
+            vk::MemoryPropertyFlagBits::eHostCoherent |
+            vk::MemoryPropertyFlagBits::eHostCached;
+        vk::BufferUsageFlags uniform_buffer_usage =
+            vk::BufferUsageFlagBits::eUniformBuffer;
+        _uniform_buffer = std::make_unique<Buffer>(*_device,
+                                                   *_memory_pool,
+                                                   *_transfer_command_pool,
+                                                   _transfer_queue,
+                                                   uniform_buffer_usage,
+                                                   uniform_memory_properties);
     }
 
     void Renderer::record_commands() {

--- a/src/Graphics/Vulkan/Renderer.hpp
+++ b/src/Graphics/Vulkan/Renderer.hpp
@@ -9,6 +9,7 @@
 
 #include "../../Log/Log.hpp"
 #include "../Renderer.hpp"
+#include "./Buffer.hpp"
 #include "./CommandPool.hpp"
 #include "./Debugger.hpp"
 #include "./DescriptorPool.hpp"
@@ -69,6 +70,11 @@ namespace Dynamo::Graphics::Vulkan {
 
         std::vector<vk::UniqueCommandBuffer> _graphics_command_buffers;
         std::vector<vk::UniqueCommandBuffer> _transfer_command_buffers;
+
+        // Buffers
+        std::unique_ptr<Buffer> _staging_buffer;
+        std::unique_ptr<Buffer> _object_buffer;
+        std::unique_ptr<Buffer> _uniform_buffer;
 
         // Synchronizers
         // Semaphores synchronize the graphic and present commands
@@ -190,6 +196,12 @@ namespace Dynamo::Graphics::Vulkan {
          *
          */
         void create_command_buffers();
+
+        /**
+         * @brief Create the buffers for reading and writing data to the GPU
+         *
+         */
+        void create_buffers();
 
         /**
          * @brief Record the draw commands

--- a/src/Utils/Allocator.hpp
+++ b/src/Utils/Allocator.hpp
@@ -4,10 +4,9 @@
 #include <optional>
 #include <unordered_map>
 
-#include "../../Log/Log.hpp"
-#include "../../Utils/Bits.hpp"
+#include "../Log/Log.hpp"
 
-namespace Dynamo::Graphics::Vulkan {
+namespace Dynamo {
     /**
      * @brief Round up a size to be a multiple of alignment
      *
@@ -20,8 +19,8 @@ namespace Dynamo::Graphics::Vulkan {
     }
 
     /**
-     * @brief Implements the block allocation and deallocation strategy for
-     * dynamic heap memory management
+     * @brief Implements the allocation and deallocation strategy for
+     * dynamic virtual heap memory management
      *
      */
     class Allocator {
@@ -31,6 +30,8 @@ namespace Dynamo::Graphics::Vulkan {
         };
         std::list<Block> _free;
         std::unordered_map<unsigned, unsigned> _used;
+
+        unsigned _capacity;
 
         /**
          * @brief Join adjacent blocks
@@ -51,9 +52,6 @@ namespace Dynamo::Graphics::Vulkan {
          * @brief Reserve a block of memory with specific alignment
          * requirements, returning the offset within the pool.
          *
-         * This find the first free block that will fit the size (with the given
-         * offset alignment) and allocate.
-         *
          * @param size      Desired size in bytes
          * @param alignment Alignment requirement in bytes
          * @return std::optional<unsigned>
@@ -63,19 +61,46 @@ namespace Dynamo::Graphics::Vulkan {
         /**
          * @brief Free the block of reserved memory at an offset
          *
-         * This will iterate over the free blocks and find the first one whose
-         * right boundary coincides with the allocated offset. This block and
-         * the next are then merged together, minimizing defragmentation.
-         *
          * @param offset Offset within the pool in bytes returned by reserve()
          */
         void free(unsigned offset);
+
+        /**
+         * @brief Grow the total capacity, expanding the free blocks
+         *
+         * @param capacity New capacity in bytes >= current_capacity
+         */
+        void grow(unsigned capacity);
+
+        /**
+         * @brief Check if an offset is mapped to a reserved block
+         *
+         * @param offset Offset within the pool in bytes returned by reserve()
+         * @return true
+         * @return false
+         */
+        bool is_reserved(unsigned offset) const;
+
+        /**
+         * @brief Get the capacity of the allocator
+         *
+         * @return unsigned
+         */
+        unsigned capacity() const;
+
+        /**
+         * @brief Get the size of a reserved block
+         *
+         * @param offset Offset within the pool in bytes returned by reserve()
+         * @return unsigned
+         */
+        unsigned size(unsigned offset) const;
 
         /**
          * @brief Generate the human-readable string to visualize the state
          * of the allocator (for debugging)
          *
          */
-        std::string print();
+        std::string print() const;
     };
-} // namespace Dynamo::Graphics::Vulkan
+} // namespace Dynamo

--- a/tests/src/Allocator-Test.cpp
+++ b/tests/src/Allocator-Test.cpp
@@ -1,0 +1,160 @@
+#include <Dynamo.hpp>
+#include <catch2/catch_test_macros.hpp>
+
+TEST_CASE("Allocator Reserve", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    Dynamo::Log::info("Test Reserve - {}", allocator.print());
+
+    std::optional<unsigned> a = allocator.reserve(7, 1);
+    REQUIRE(a.has_value());
+    REQUIRE(a.value() == 0);
+    Dynamo::Log::info("Test Reserve - {}", allocator.print());
+
+    std::optional<unsigned> b = allocator.reserve(3, 1);
+    REQUIRE(b.has_value());
+    REQUIRE(b.value() == 7);
+    Dynamo::Log::info("Test Reserve - {}", allocator.print());
+
+    std::optional<unsigned> c = allocator.reserve(1, 1);
+    REQUIRE(!c.has_value());
+    Dynamo::Log::info("Test Reserve - {}", allocator.print());
+}
+
+TEST_CASE("Allocator Reserve Alignment", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    Dynamo::Log::info("Test Reserve Alignment - {}", allocator.print());
+
+    std::optional<unsigned> a = allocator.reserve(5, 3);
+    REQUIRE(a.has_value());
+    REQUIRE(a.value() == 0);
+    Dynamo::Log::info("Test Reserve Alignment - {}", allocator.print());
+
+    std::optional<unsigned> b = allocator.reserve(3, 3);
+    REQUIRE(b.has_value());
+    REQUIRE(b.value() == 6);
+    Dynamo::Log::info("Test Reserve Alignment - {}", allocator.print());
+
+    std::optional<unsigned> c = allocator.reserve(4, 3);
+    REQUIRE(!c.has_value());
+    Dynamo::Log::info("Test Reserve Alignment - {}", allocator.print());
+
+    std::optional<unsigned> d = allocator.reserve(1, 1);
+    REQUIRE(d.has_value());
+    REQUIRE(d.value() == 5);
+    Dynamo::Log::info("Test Reserve Alignment - {}", allocator.print());
+
+    std::optional<unsigned> e = allocator.reserve(1, 1);
+    REQUIRE(e.has_value());
+    REQUIRE(e.value() == 9);
+    Dynamo::Log::info("Test Reserve Alignment - {}", allocator.print());
+
+    // Memory full
+    std::optional<unsigned> f = allocator.reserve(1, 1);
+    REQUIRE(!f.has_value());
+    Dynamo::Log::info("Test Reserve Alignment - {}", allocator.print());
+}
+
+TEST_CASE("Allocator Free", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    Dynamo::Log::info("Test Free - {}", allocator.print());
+
+    std::optional<unsigned> a = allocator.reserve(5, 1);
+    REQUIRE(a.has_value());
+    REQUIRE(a.value() == 0);
+    Dynamo::Log::info("Test Free - {}", allocator.print());
+
+    std::optional<unsigned> b = allocator.reserve(5, 1);
+    REQUIRE(b.has_value());
+    REQUIRE(b.value() == 5);
+    allocator.print();
+    Dynamo::Log::info("Test Free - {}", allocator.print());
+
+    REQUIRE_NOTHROW(allocator.free(a.value()));
+    Dynamo::Log::info("Test Free - {}", allocator.print());
+
+    std::optional<unsigned> c = allocator.reserve(5, 1);
+    REQUIRE(c.has_value());
+    REQUIRE(c.value() == 0);
+    allocator.print();
+    Dynamo::Log::info("Test Free - {}", allocator.print());
+}
+
+TEST_CASE("Allocator Resize", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    Dynamo::Log::info("Test Resize - {}", allocator.print());
+
+    std::optional<unsigned> a = allocator.reserve(7, 5);
+    REQUIRE(a.has_value());
+    REQUIRE(a.value() == 0);
+    Dynamo::Log::info("Test Resize - {}", allocator.print());
+
+    std::optional<unsigned> b = allocator.reserve(2, 2);
+    REQUIRE(b.has_value());
+    REQUIRE(b.value() == 8);
+    Dynamo::Log::info("Test Resize - {}", allocator.print());
+
+    allocator.grow(20);
+    Dynamo::Log::info("Test Resize - {}", allocator.print());
+
+    std::optional<unsigned> d = allocator.reserve(6, 2);
+    REQUIRE(d.has_value());
+    REQUIRE(d.value() == 10);
+    Dynamo::Log::info("Test Resize - {}", allocator.print());
+}
+
+TEST_CASE("Allocator Resize Full", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    std::optional<unsigned> e = allocator.reserve(10, 1);
+    REQUIRE(e.has_value());
+    REQUIRE(e.value() == 0);
+    Dynamo::Log::info("Test Resize Full - {}", allocator.print());
+
+    allocator.grow(20);
+    std::optional<unsigned> f = allocator.reserve(5, 1);
+    REQUIRE(f.has_value());
+    REQUIRE(f.value() == 10);
+    Dynamo::Log::info("Test Resize Full - {}", allocator.print());
+
+    allocator.grow(40);
+    std::optional<unsigned> g = allocator.reserve(10, 1);
+    REQUIRE(g.has_value());
+    REQUIRE(g.value() == 15);
+    Dynamo::Log::info("Test Resize Full - {}", allocator.print());
+}
+
+TEST_CASE("Allocator is allocated", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    std::optional<unsigned> a = allocator.reserve(7, 5);
+    REQUIRE(allocator.is_reserved(a.value()));
+
+    allocator.free(a.value());
+
+    REQUIRE(!allocator.is_reserved(a.value()));
+}
+
+TEST_CASE("Allocator capacity", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    REQUIRE(allocator.capacity() == 10);
+
+    allocator.grow(20);
+    REQUIRE(allocator.capacity() == 20);
+
+    REQUIRE_THROWS(allocator.grow(3));
+}
+
+TEST_CASE("Allocator block size", "[Allocator]") {
+    Dynamo::Allocator allocator(10);
+    Dynamo::Log::info("Test Block Size - {}", allocator.print());
+
+    std::optional<unsigned> a = allocator.reserve(7, 1);
+    REQUIRE(allocator.size(a.value()) == 7);
+    Dynamo::Log::info("Test Block Size - {}", allocator.print());
+
+    std::optional<unsigned> b = allocator.reserve(3, 1);
+    REQUIRE(allocator.size(b.value()) == 3);
+    Dynamo::Log::info("Test Block Size - {}", allocator.print());
+
+    std::optional<unsigned> c = allocator.reserve(1, 1);
+    REQUIRE_THROWS(allocator.size(c.value()));
+    Dynamo::Log::info("Test Block Size - {}", allocator.print());
+}


### PR DESCRIPTION
This will allow creating the object, uniform, and staging buffers for uploading mesh and descriptor data.

Requirements:
* Buffer needs to be dynamic (realloc to increase capacity)
* Fast allocator for sub-buffers with minimal fragmentation

Solution to this is straightforward: Use the existing `Allocator` and `MemoryPool` objects to handle the memory management heavy lifting.

I probably have to implement a `resize()` method for `Allocator` in the event of a Buffer realloc.