### PR TITLE
Sort models to minimize costly renderpass and pipeline rebindings

### DIFF
--- a/src/Graphics/Renderer.hpp
+++ b/src/Graphics/Renderer.hpp
@@ -56,7 +56,6 @@ namespace Dynamo::Graphics {
         // * Depth-stencil buffer
         // * Texture system -> Similar to shaders / meshes, generate a handle and return
         // * Draw-to-texture -> overload render(), render(Texture texture)
-        // * Group draws by renderpass / pipeline / pipeline layout
 
         /**
          * @brief Rebuild the swapchain.

--- a/src/Graphics/Vulkan/Buffer.cpp
+++ b/src/Graphics/Vulkan/Buffer.cpp
@@ -67,8 +67,6 @@ namespace Dynamo::Graphics::Vulkan {
     unsigned Buffer::size(unsigned block_offset) const { return _allocator.size(block_offset); }
 
     void Buffer::resize(unsigned size) {
-        // !!TODO!!: Do not destroy old buffer, as this will invalidate handles for all active resources.
-
         // Do not resize if target is less than the current capacity
         if (size < _allocator.capacity()) return;
 
@@ -98,14 +96,9 @@ namespace Dynamo::Graphics::Vulkan {
         _allocator.grow(size);
     }
 
-    void Buffer::host_write(const void *src, unsigned block_offset, unsigned length) {
-        DYN_ASSERT(_allocator.is_reserved(block_offset));
-        std::memcpy(_mapped + block_offset, src, length);
-    }
-
-    void Buffer::host_read(void *dst, unsigned block_offset, unsigned length) {
-        DYN_ASSERT(_allocator.is_reserved(block_offset));
-        std::memcpy(dst, _mapped + block_offset, length);
+    void *Buffer::get_mapped(unsigned block_offset) {
+        DYN_ASSERT(_allocator.is_reserved(block_offset) && _mapped != nullptr);
+        return _mapped + block_offset;
     }
 
     void Buffer::copy_to(Buffer &dst, VkBufferCopy *regions, unsigned region_count) {

--- a/src/Graphics/Vulkan/Buffer.hpp
+++ b/src/Graphics/Vulkan/Buffer.hpp
@@ -96,22 +96,12 @@ namespace Dynamo::Graphics::Vulkan {
         void resize(unsigned size);
 
         /**
-         * @brief Write to the buffer.
+         * @brief Get a pointer to mapped memory.
          *
-         * @param src
          * @param block_offset
-         * @param length
+         * @return void*
          */
-        void host_write(const void *src, unsigned block_offset, unsigned length);
-
-        /**
-         * @brief Read from the buffer.
-         *
-         * @param dst
-         * @param block_offset
-         * @param length
-         */
-        void host_read(void *dst, unsigned block_offset, unsigned length);
+        void *get_mapped(unsigned block_offset);
 
         /**
          * @brief Copy contents to another buffer.

--- a/src/Graphics/Vulkan/MaterialRegistry.cpp
+++ b/src/Graphics/Vulkan/MaterialRegistry.cpp
@@ -203,11 +203,9 @@ namespace Dynamo::Graphics::Vulkan {
 
         // Aggregate descriptor layouts
         std::vector<VkDescriptorSetLayout> descriptor_layouts;
-        descriptor_layouts.reserve(vertex_module.descriptor_sets.size() + fragment_module.descriptor_sets.size());
         for (const DescriptorSet &set : vertex_module.descriptor_sets) {
             descriptor_layouts.push_back(set.layout);
 
-            // TODO: What if we have duplicate set layouts? Need to get unique descriptor layouts to build sets
             DescriptorAllocation allocation = uniforms.allocate(set);
             instance.descriptor_sets.push_back(allocation.set);
             for (Uniform uniform : allocation.uniforms) {
@@ -217,7 +215,7 @@ namespace Dynamo::Graphics::Vulkan {
         for (const DescriptorSet &set : fragment_module.descriptor_sets) {
             descriptor_layouts.push_back(set.layout);
 
-            // TODO: Same problem here, we need to aggregate unique layouts
+            // TODO: What if we have duplicate set layouts? Need to get unique descriptor layouts to build sets
             DescriptorAllocation allocation = uniforms.allocate(set);
             instance.descriptor_sets.push_back(allocation.set);
             for (Uniform uniform : allocation.uniforms) {
@@ -227,7 +225,6 @@ namespace Dynamo::Graphics::Vulkan {
 
         // Aggregate push constant ranges
         std::vector<VkPushConstantRange> push_constant_ranges;
-        push_constant_ranges.reserve(vertex_module.push_constants.size() + fragment_module.push_constants.size());
         for (const PushConstant &push_constant : vertex_module.push_constants) {
             push_constant_ranges.push_back(push_constant.range);
 

--- a/src/Graphics/Vulkan/MaterialRegistry.hpp
+++ b/src/Graphics/Vulkan/MaterialRegistry.hpp
@@ -39,8 +39,8 @@ namespace Dynamo::Graphics::Vulkan {
                 size_t hash0 = std::hash<bool>{}(settings.clear_color);
                 size_t hash1 = std::hash<bool>{}(settings.clear_depth);
 
-                size_t hash2 = std::hash<unsigned>{}(settings.color_format);
-                size_t hash3 = std::hash<unsigned>{}(settings.depth_format);
+                size_t hash2 = std::hash<VkFormat>{}(settings.color_format);
+                size_t hash3 = std::hash<VkFormat>{}(settings.depth_format);
 
                 size_t hash4 = std::hash<unsigned>{}(settings.sample_count);
 
@@ -84,12 +84,12 @@ namespace Dynamo::Graphics::Vulkan {
             inline size_t operator()(const PipelineLayoutSettings &settings) const {
                 size_t hash_base = 0;
                 for (unsigned i = 0; i < settings.descriptor_layout_count; i++) {
-                    VkDescriptorSetLayout &layout = settings.descriptor_layouts[i];
-                    size_t hash = std::hash<const void *>{}(layout);
+                    VkDescriptorSetLayout layout = settings.descriptor_layouts[i];
+                    size_t hash = std::hash<VkDescriptorSetLayout>{}(layout);
                     hash_base ^= (hash << i);
                 }
                 for (unsigned i = 0; i < settings.push_constant_range_count; i++) {
-                    VkPushConstantRange &range = settings.push_constant_ranges[i];
+                    const VkPushConstantRange &range = settings.push_constant_ranges[i];
                     size_t hash0 = std::hash<unsigned>{}(range.size);
                     size_t hash1 = std::hash<unsigned>{}(range.offset);
                     size_t hash2 = std::hash<unsigned>{}(range.stageFlags);
@@ -123,9 +123,9 @@ namespace Dynamo::Graphics::Vulkan {
 
         struct Hash {
             inline size_t operator()(const GraphicsPipelineSettings &settings) const {
-                size_t hash0 = std::hash<unsigned>{}(settings.topology);
-                size_t hash1 = std::hash<unsigned>{}(settings.polygon_mode);
-                size_t hash2 = std::hash<unsigned>{}(settings.cull_mode);
+                size_t hash0 = std::hash<VkPrimitiveTopology>{}(settings.topology);
+                size_t hash1 = std::hash<VkPolygonMode>{}(settings.polygon_mode);
+                size_t hash2 = std::hash<VkCullModeFlags>{}(settings.cull_mode);
                 size_t hash3 = std::hash<VkShaderModule>{}(settings.vertex.handle);
                 size_t hash4 = std::hash<VkShaderModule>{}(settings.fragment.handle);
                 size_t hash5 = std::hash<VkRenderPass>{}(settings.renderpass);

--- a/src/Graphics/Vulkan/MeshRegistry.cpp
+++ b/src/Graphics/Vulkan/MeshRegistry.cpp
@@ -42,7 +42,9 @@ namespace Dynamo::Graphics::Vulkan {
             region.size = attribute.size();
 
             unsigned staging_offset = _staging.reserve(attribute.size());
-            _staging.host_write(attribute.data(), staging_offset, attribute.size());
+            void *ptr = _staging.get_mapped(staging_offset);
+            std::memcpy(ptr, attribute.data(), attribute.size());
+
             _staging.copy_to(_vertex, &region, 1);
             _staging.free(staging_offset);
         }
@@ -50,11 +52,11 @@ namespace Dynamo::Graphics::Vulkan {
         // Write index array, if available
         switch (descriptor.index_type) {
         case IndexType::U16: {
-            std::vector<uint16_t> short_indices;
+            std::vector<uint16_t> u16_indices;
             for (unsigned index : descriptor.indices) {
-                short_indices.push_back(index);
+                u16_indices.push_back(index);
             }
-            unsigned size = short_indices.size() * sizeof(short_indices[0]);
+            unsigned size = u16_indices.size() * sizeof(u16_indices[0]);
             allocation.index_offset = _index.reserve(size);
 
             VkBufferCopy region;
@@ -63,7 +65,9 @@ namespace Dynamo::Graphics::Vulkan {
             region.size = size;
 
             unsigned staging_offset = _staging.reserve(size);
-            _staging.host_write(short_indices.data(), staging_offset, size);
+            void *ptr = _staging.get_mapped(staging_offset);
+            std::memcpy(ptr, u16_indices.data(), size);
+
             _staging.copy_to(_index, &region, 1);
             _staging.free(staging_offset);
 
@@ -71,11 +75,11 @@ namespace Dynamo::Graphics::Vulkan {
             break;
         }
         case IndexType::U32: {
-            std::vector<uint32_t> short_indices;
+            std::vector<uint32_t> u32_indices;
             for (unsigned index : descriptor.indices) {
-                short_indices.push_back(index);
+                u32_indices.push_back(index);
             }
-            unsigned size = short_indices.size() * sizeof(short_indices[0]);
+            unsigned size = u32_indices.size() * sizeof(u32_indices[0]);
             allocation.index_offset = _index.reserve(size);
 
             VkBufferCopy region;
@@ -84,7 +88,9 @@ namespace Dynamo::Graphics::Vulkan {
             region.size = size;
 
             unsigned staging_offset = _staging.reserve(size);
-            _staging.host_write(short_indices.data(), staging_offset, size);
+            void *ptr = _staging.get_mapped(staging_offset);
+            std::memcpy(ptr, u32_indices.data(), size);
+
             _staging.copy_to(_index, &region, 1);
             _staging.free(staging_offset);
 

--- a/src/Graphics/Vulkan/ShaderRegistry.hpp
+++ b/src/Graphics/Vulkan/ShaderRegistry.hpp
@@ -42,9 +42,9 @@ namespace Dynamo::Graphics::Vulkan {
                 for (const VkDescriptorSetLayoutBinding &binding : layout.bindings) {
                     size_t hash0 = std::hash<unsigned>{}(binding.binding);
                     size_t hash1 = std::hash<unsigned>{}(binding.descriptorCount);
-                    size_t hash2 = std::hash<unsigned>{}(binding.descriptorType);
-                    size_t hash3 = std::hash<unsigned>{}(binding.stageFlags);
-                    size_t hash4 = std::hash<const void *>{}(binding.pImmutableSamplers);
+                    size_t hash2 = std::hash<VkDescriptorType>{}(binding.descriptorType);
+                    size_t hash3 = std::hash<VkShaderStageFlags>{}(binding.stageFlags);
+                    size_t hash4 = std::hash<const VkSampler *>{}(binding.pImmutableSamplers);
 
                     size_t binding_hash = hash0 ^ (hash1 << 1) ^ (hash2 << 2) ^ (hash3 << 3) ^ (hash4 << 4);
                     hash_base ^= binding_hash;

--- a/src/Graphics/Vulkan/UniformRegistry.hpp
+++ b/src/Graphics/Vulkan/UniformRegistry.hpp
@@ -1,7 +1,5 @@
 #pragma once
 
-#include <unordered_map>
-
 #include <vulkan/vulkan_core.h>
 
 #include <Graphics/Vulkan/Buffer.hpp>
@@ -61,8 +59,6 @@ namespace Dynamo::Graphics::Vulkan {
         VkDescriptorPool _pool;
         Buffer _uniform_buffer;
         VirtualMemory _push_constant_buffer;
-
-        std::unordered_map<VkDescriptorSetLayout, VkDescriptorSet> _sets;
         SparseArray<Uniform, UniformVariable> _variables;
 
       public:

--- a/src/Utils/VirtualMemory.cpp
+++ b/src/Utils/VirtualMemory.cpp
@@ -25,7 +25,7 @@ namespace Dynamo {
 
     void VirtualMemory::free(unsigned block_offset) { _allocator.free(block_offset); }
 
-    void *VirtualMemory::get(unsigned block_offset) {
+    void *VirtualMemory::get_mapped(unsigned block_offset) {
         DYN_ASSERT(_allocator.is_reserved(block_offset));
         return _buffer.data() + block_offset;
     }

--- a/src/Utils/VirtualMemory.hpp
+++ b/src/Utils/VirtualMemory.hpp
@@ -42,10 +42,10 @@ namespace Dynamo {
         void free(unsigned block_offset);
 
         /**
-         * @brief Get the pointer to an allocated block.
+         * @brief Get the pointer to mapped memory.
          *
          * @return void*
          */
-        void *get(unsigned block_offset);
+        void *get_mapped(unsigned block_offset);
     };
 } // namespace Dynamo

--- a/tests/src/Utils/VirtualMemory.cpp
+++ b/tests/src/Utils/VirtualMemory.cpp
@@ -8,7 +8,7 @@ TEST_CASE("VirtualMemory reserve", "[VirtualMemory]") {
 
     REQUIRE(offset == 4);
     REQUIRE(memory.size(offset) == 12);
-    REQUIRE(memory.get(offset) != nullptr);
+    REQUIRE(memory.get_mapped(offset) != nullptr);
 }
 
 TEST_CASE("VirtualMemory free", "[VirtualMemory]") {
@@ -17,7 +17,7 @@ TEST_CASE("VirtualMemory free", "[VirtualMemory]") {
 
     REQUIRE(offset == 0);
     REQUIRE(memory.size(offset) == 3);
-    REQUIRE(memory.get(offset) != nullptr);
+    REQUIRE(memory.get_mapped(offset) != nullptr);
 
     memory.free(offset);
     REQUIRE_THROWS(memory.size(offset));


### PR DESCRIPTION
* Remove Buffer::host_read() and host_write(), replace with get_mapped()
* Rename VirtualMemory::get() to get_mapped()