### PR TITLE
Remove default initialization of Renderer submodules

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -23,3 +23,5 @@ BreakBeforeTernaryOperators: true
 BreakConstructorInitializers: AfterColon
 BreakInheritanceList: AfterColon
 BreakStringLiterals: true
+PackConstructorInitializers: CurrentLine
+AlignAfterOpenBracket: true

--- a/src/Graphics/Renderer.hpp
+++ b/src/Graphics/Renderer.hpp
@@ -14,36 +14,26 @@
 #include <Graphics/Vulkan/Swapchain.hpp>
 #include <Graphics/Vulkan/TextureRegistry.hpp>
 #include <Graphics/Vulkan/UniformRegistry.hpp>
+#include <Graphics/Vulkan/VulkanContext.hpp>
 #include <Math/Color.hpp>
 
 namespace Dynamo::Graphics {
-    using namespace Vulkan;
-
     /**
      * @brief Vulkan-powered 3D Renderer.
      *
      */
     class Renderer {
         const Display &_display;
+        Vulkan::VulkanContext _context;
+        Vulkan::Swapchain _swapchain;
 
-        VkInstance _instance;
-        VkDebugUtilsMessengerEXT _debugger;
-        VkSurfaceKHR _surface;
-
-        PhysicalDevice _physical;
-        VkDevice _device;
-
-        Swapchain _swapchain;
-
-        VkCommandPool _graphics_pool;
-        VkCommandPool _transfer_pool;
-
-        MemoryPool _memory;
-        MeshRegistry _meshes;
-        ShaderRegistry _shaders;
-        PipelineRegistry _pipelines;
-        UniformRegistry _uniforms;
-        TextureRegistry _textures;
+        Vulkan::MemoryPool _memory;
+        Vulkan::MeshRegistry _meshes;
+        Vulkan::ShaderRegistry _shaders;
+        Vulkan::PipelineRegistry _pipelines;
+        Vulkan::UniformRegistry _uniforms;
+        Vulkan::TextureRegistry _textures;
+        Vulkan::FrameContextList _frame_contexts;
 
         Texture _color_texture;
         Texture _depth_stencil_texture;
@@ -51,8 +41,6 @@ namespace Dynamo::Graphics {
         VkRenderPass _forwardpass;
         std::vector<VkFramebuffer> _framebuffers;
         std::array<VkClearValue, 2> _clear;
-
-        FrameContextList _frame_contexts;
 
         std::vector<Model> _models;
 

--- a/src/Graphics/Vulkan/FrameContext.cpp
+++ b/src/Graphics/Vulkan/FrameContext.cpp
@@ -16,17 +16,17 @@ namespace Dynamo::Graphics::Vulkan {
         }
     }
 
-    const FrameContext &FrameContextList::next() {
-        FrameContext &context = _contexts[_index];
-        _index = (_index + 1) % MAX_FRAMES_IN_FLIGHT;
-        return context;
-    }
-
-    void FrameContextList::destroy() {
+    FrameContextList::~FrameContextList() {
         for (const FrameContext &context : _contexts) {
             vkDestroyFence(_device, context.sync_fence, nullptr);
             vkDestroySemaphore(_device, context.sync_render_start, nullptr);
             vkDestroySemaphore(_device, context.sync_render_done, nullptr);
         }
+    }
+
+    const FrameContext &FrameContextList::next() {
+        FrameContext &context = _contexts[_index];
+        _index = (_index + 1) % MAX_FRAMES_IN_FLIGHT;
+        return context;
     }
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/FrameContext.hpp
+++ b/src/Graphics/Vulkan/FrameContext.hpp
@@ -22,10 +22,8 @@ namespace Dynamo::Graphics::Vulkan {
 
       public:
         FrameContextList(VkDevice device, VkCommandPool command_pool);
-        FrameContextList() = default;
+        ~FrameContextList();
 
         const FrameContext &next();
-
-        void destroy();
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/MemoryPool.hpp
+++ b/src/Graphics/Vulkan/MemoryPool.hpp
@@ -43,7 +43,7 @@ namespace Dynamo::Graphics::Vulkan {
         using MemoryGroup = std::vector<Memory>;
 
         VkDevice _device;
-        const PhysicalDevice *_physical;
+        const PhysicalDevice &_physical;
         std::vector<MemoryGroup> _groups;
 
         unsigned find_type_index(const VkMemoryRequirements &requirements, VkMemoryPropertyFlags properties) const;
@@ -52,7 +52,7 @@ namespace Dynamo::Graphics::Vulkan {
 
       public:
         MemoryPool(VkDevice device, const PhysicalDevice &physical);
-        MemoryPool() = default;
+        ~MemoryPool();
 
         VirtualBuffer build(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, unsigned size);
 
@@ -70,7 +70,5 @@ namespace Dynamo::Graphics::Vulkan {
         void free(const VirtualBuffer &allocation);
 
         void free(const VirtualImage &allocation);
-
-        void destroy();
     };
 }; // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/MeshRegistry.cpp
+++ b/src/Graphics/Vulkan/MeshRegistry.cpp
@@ -2,30 +2,45 @@
 #include <Graphics/Vulkan/Utils.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    MeshRegistry::MeshRegistry(VkDevice device, const PhysicalDevice &physical, VkCommandPool transfer_pool) {
+    MeshRegistry::MeshRegistry(VkDevice device,
+                               const PhysicalDevice &physical,
+                               MemoryPool &memory,
+                               VkCommandPool transfer_pool) :
+        _device(device),
+        _memory(memory) {
         VkCommandBuffer_allocate(_device, transfer_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &_command_buffer, 1);
         vkGetDeviceQueue(_device, physical.transfer_queues.index, 0, &_transfer_queue);
     }
 
-    void MeshRegistry::write_vertices(MemoryPool &memory, const void *src, VirtualBuffer &dst, unsigned size) {
+    MeshRegistry::~MeshRegistry() {
+        _instances.foreach ([&](MeshInstance &instance) {
+            for (VirtualBuffer &buffer : instance.virtual_buffers) {
+                _memory.free(buffer);
+            }
+        });
+        _instances.clear();
+    }
+
+    void MeshRegistry::write_vertices(const void *src, VirtualBuffer &dst, unsigned size) {
         VkBufferCopy region;
         region.srcOffset = 0;
         region.dstOffset = dst.offset;
         region.size = size;
 
-        VirtualBuffer staging = memory.build(VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
-                                             VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
-                                             size);
+        VirtualBuffer staging =
+            _memory.build(VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                          VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT | VK_MEMORY_PROPERTY_HOST_COHERENT_BIT,
+                          size);
         std::memcpy(staging.mapped, src, size);
 
         VkCommandBuffer_immediate_start(_command_buffer);
         vkCmdCopyBuffer(_command_buffer, staging.buffer, dst.buffer, 1, &region);
         VkCommandBuffer_immediate_end(_command_buffer, _transfer_queue);
 
-        memory.free(staging);
+        _memory.free(staging);
     }
 
-    Mesh MeshRegistry::build(const MeshDescriptor &descriptor, MemoryPool &memory) {
+    Mesh MeshRegistry::build(const MeshDescriptor &descriptor) {
         // Set the vertex, instance, and index counts
         MeshInstance instance;
         instance.vertex_count = descriptor.vertex_count;
@@ -34,14 +49,14 @@ namespace Dynamo::Graphics::Vulkan {
 
         // Write attributes to the buffers
         for (auto &attribute : descriptor.attributes) {
-            VirtualBuffer vertex = memory.build(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                                                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                                attribute.size());
+            VirtualBuffer vertex = _memory.build(VK_BUFFER_USAGE_VERTEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                                 VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                                 attribute.size());
             instance.attribute_offsets.push_back(vertex.offset);
             instance.buffers.push_back(vertex.buffer);
             instance.virtual_buffers.push_back(vertex);
 
-            write_vertices(memory, attribute.data(), vertex, attribute.size());
+            write_vertices(attribute.data(), vertex, attribute.size());
         }
 
         // Write index array, if available
@@ -54,14 +69,14 @@ namespace Dynamo::Graphics::Vulkan {
                 u16_indices.push_back(index);
             }
             unsigned size = u16_indices.size() * 2;
-            VirtualBuffer index = memory.build(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                               size);
+            VirtualBuffer index = _memory.build(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                                size);
             instance.index_buffer = index.buffer;
             instance.index_offset = index.offset;
             instance.virtual_buffers.push_back(index);
 
-            write_vertices(memory, u16_indices.data(), index, size);
+            write_vertices(u16_indices.data(), index, size);
             break;
         }
         case IndexType::U32: {
@@ -72,14 +87,14 @@ namespace Dynamo::Graphics::Vulkan {
                 u32_indices.push_back(index);
             }
             unsigned size = u32_indices.size() * 4;
-            VirtualBuffer index = memory.build(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
-                                               VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
-                                               size);
+            VirtualBuffer index = _memory.build(VK_BUFFER_USAGE_INDEX_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT,
+                                                VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT,
+                                                size);
             instance.index_buffer = index.buffer;
             instance.index_offset = index.offset;
             instance.virtual_buffers.push_back(index);
 
-            write_vertices(memory, u32_indices.data(), index, size);
+            write_vertices(u32_indices.data(), index, size);
             break;
         }
         case IndexType::None:
@@ -93,20 +108,11 @@ namespace Dynamo::Graphics::Vulkan {
 
     MeshInstance &MeshRegistry::get(Mesh mesh) { return _instances.get(mesh); }
 
-    void MeshRegistry::destroy(Mesh mesh, MemoryPool &memory) {
+    void MeshRegistry::destroy(Mesh mesh) {
         MeshInstance &instance = _instances.get(mesh);
         for (VirtualBuffer &buffer : instance.virtual_buffers) {
-            memory.free(buffer);
+            _memory.free(buffer);
         }
         _instances.remove(mesh);
-    }
-
-    void MeshRegistry::destroy(MemoryPool &memory) {
-        _instances.foreach ([&](MeshInstance &instance) {
-            for (VirtualBuffer &buffer : instance.virtual_buffers) {
-                memory.free(buffer);
-            }
-        });
-        _instances.clear();
     }
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/MeshRegistry.hpp
+++ b/src/Graphics/Vulkan/MeshRegistry.hpp
@@ -25,20 +25,19 @@ namespace Dynamo::Graphics::Vulkan {
         VkDevice _device;
         VkCommandBuffer _command_buffer;
         VkQueue _transfer_queue;
+        MemoryPool &_memory;
         SparseArray<Mesh, MeshInstance> _instances;
 
-        void write_vertices(MemoryPool &memory, const void *src, VirtualBuffer &dst, unsigned size);
+        void write_vertices(const void *src, VirtualBuffer &dst, unsigned size);
 
       public:
-        MeshRegistry(VkDevice device, const PhysicalDevice &physical, VkCommandPool transfer_pool);
-        MeshRegistry() = default;
+        MeshRegistry(VkDevice device, const PhysicalDevice &physical, MemoryPool &memory, VkCommandPool transfer_pool);
+        ~MeshRegistry();
 
         MeshInstance &get(Mesh mesh);
 
-        Mesh build(const MeshDescriptor &descriptor, MemoryPool &memory);
+        Mesh build(const MeshDescriptor &descriptor);
 
-        void destroy(Mesh mesh, MemoryPool &memory);
-
-        void destroy(MemoryPool &memory);
+        void destroy(Mesh mesh);
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/PhysicalDevice.cpp
+++ b/src/Graphics/Vulkan/PhysicalDevice.cpp
@@ -1,7 +1,6 @@
 #include <Graphics/Vulkan/PhysicalDevice.hpp>
 #include <Graphics/Vulkan/Utils.hpp>
 #include <Utils/Log.hpp>
-#include <vulkan/vulkan_core.h>
 
 namespace Dynamo::Graphics::Vulkan {
     PhysicalDevice::PhysicalDevice(VkPhysicalDevice handle, VkSurfaceKHR surface) : handle(handle), surface(surface) {

--- a/src/Graphics/Vulkan/PhysicalDevice.hpp
+++ b/src/Graphics/Vulkan/PhysicalDevice.hpp
@@ -5,7 +5,6 @@
 #include <vulkan/vulkan_core.h>
 
 namespace Dynamo::Graphics::Vulkan {
-
     struct QueueFamily {
         unsigned index = 0;
         unsigned count = 0;
@@ -37,7 +36,6 @@ namespace Dynamo::Graphics::Vulkan {
         QueueFamily transfer_queues;
 
         PhysicalDevice(VkPhysicalDevice handle, VkSurfaceKHR surface);
-        PhysicalDevice() = default;
 
         static PhysicalDevice select_best(VkInstance instance, VkSurfaceKHR surface);
 

--- a/src/Graphics/Vulkan/PipelineRegistry.hpp
+++ b/src/Graphics/Vulkan/PipelineRegistry.hpp
@@ -110,7 +110,7 @@ namespace Dynamo::Graphics::Vulkan {
 
     class PipelineRegistry {
         VkDevice _device;
-        const PhysicalDevice *_physical;
+        const PhysicalDevice &_physical;
 
         std::ofstream _ofstream;
         VkPipelineCache _pipeline_cache;
@@ -122,7 +122,7 @@ namespace Dynamo::Graphics::Vulkan {
 
       public:
         PipelineRegistry(VkDevice device, const PhysicalDevice &physical, const std::string &filename);
-        PipelineRegistry() = default;
+        ~PipelineRegistry();
 
         Pipeline build(const PipelineDescriptor &descriptor,
                        VkRenderPass renderpass,
@@ -132,8 +132,6 @@ namespace Dynamo::Graphics::Vulkan {
                        MemoryPool &memory);
 
         PipelineInstance &get(Pipeline pipeline);
-
-        void destroy();
 
         void write_to_disk();
     };

--- a/src/Graphics/Vulkan/ShaderRegistry.cpp
+++ b/src/Graphics/Vulkan/ShaderRegistry.cpp
@@ -8,6 +8,18 @@ namespace Dynamo::Graphics::Vulkan {
 
     ShaderRegistry::ShaderRegistry(VkDevice device) : _device(device) {}
 
+    ShaderRegistry::~ShaderRegistry() {
+        // Destroy descriptor layouts
+        for (const auto &[key, layout] : _descriptor_layouts) {
+            vkDestroyDescriptorSetLayout(_device, layout, nullptr);
+        }
+        _descriptor_layouts.clear();
+
+        // Destroy shader modules
+        _modules.foreach ([&](ShaderModule &module) { vkDestroyShaderModule(_device, module.handle, nullptr); });
+        _modules.clear();
+    }
+
     std::vector<uint32_t> ShaderRegistry::compile(const std::string &name,
                                                   const std::string &code,
                                                   VkShaderStageFlagBits stage,
@@ -282,17 +294,5 @@ namespace Dynamo::Graphics::Vulkan {
         ShaderModule &module = _modules.get(shader);
         vkDestroyShaderModule(_device, module.handle, nullptr);
         _modules.remove(shader);
-    }
-
-    void ShaderRegistry::destroy() {
-        // Destroy descriptor layouts
-        for (const auto &[key, layout] : _descriptor_layouts) {
-            vkDestroyDescriptorSetLayout(_device, layout, nullptr);
-        }
-        _descriptor_layouts.clear();
-
-        // Destroy shader modules
-        _modules.foreach ([&](ShaderModule &module) { vkDestroyShaderModule(_device, module.handle, nullptr); });
-        _modules.clear();
     }
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/ShaderRegistry.hpp
+++ b/src/Graphics/Vulkan/ShaderRegistry.hpp
@@ -98,14 +98,12 @@ namespace Dynamo::Graphics::Vulkan {
 
       public:
         ShaderRegistry(VkDevice device);
-        ShaderRegistry() = default;
+        ~ShaderRegistry();
 
         const ShaderModule &get(Shader shader) const;
 
         Shader build(const ShaderDescriptor &descriptor);
 
         void destroy(Shader shader);
-
-        void destroy();
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/Swapchain.hpp
+++ b/src/Graphics/Vulkan/Swapchain.hpp
@@ -25,8 +25,8 @@ namespace Dynamo::Graphics::Vulkan {
                   const PhysicalDevice &physical,
                   const Display &display,
                   std::optional<Swapchain> previous = {});
-        Swapchain() = default;
 
+        // Need to bypass destructor call order to perform swapchain recreation
         void destroy();
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/TextureRegistry.hpp
+++ b/src/Graphics/Vulkan/TextureRegistry.hpp
@@ -53,7 +53,8 @@ namespace Dynamo::Graphics::Vulkan {
 
     class TextureRegistry {
         VkDevice _device;
-        const PhysicalDevice *_physical;
+        const PhysicalDevice &_physical;
+        MemoryPool &_memory;
 
         VkQueue _transfer_queue;
         VkCommandBuffer _command_buffer;
@@ -65,19 +66,19 @@ namespace Dynamo::Graphics::Vulkan {
                           VkImage image,
                           VkFormat format,
                           const VkExtent3D &extent,
-                          const VkImageSubresourceRange &subresources,
-                          MemoryPool &memory);
+                          const VkImageSubresourceRange &subresources);
 
       public:
-        TextureRegistry(VkDevice device, const PhysicalDevice &physical, VkCommandPool transfer_pool);
-        TextureRegistry() = default;
+        TextureRegistry(VkDevice device,
+                        const PhysicalDevice &physical,
+                        MemoryPool &memory,
+                        VkCommandPool transfer_pool);
+        ~TextureRegistry();
 
-        Texture build(const TextureDescriptor &descriptor, const Swapchain &swapchain, MemoryPool &memory);
+        Texture build(const TextureDescriptor &descriptor, const Swapchain &swapchain);
 
         const TextureInstance &get(Texture texture) const;
 
-        void destroy(Texture texture, MemoryPool &memory);
-
-        void destroy(MemoryPool &memory);
+        void destroy(Texture texture);
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/UniformRegistry.hpp
+++ b/src/Graphics/Vulkan/UniformRegistry.hpp
@@ -66,21 +66,24 @@ namespace Dynamo::Graphics::Vulkan {
     class UniformRegistry {
         VkDevice _device;
         VkDescriptorPool _pool;
+        MemoryPool &_memory;
         VirtualMemory _push_constant_buffer;
 
         std::unordered_map<std::string, SharedVariable> _shared;
         SparseArray<Uniform, UniformVariable> _variables;
 
-        VirtualBuffer
-        allocate_uniform_buffer(VkDescriptorSet descriptor_set, DescriptorBinding &binding, MemoryPool &memory);
+        VirtualBuffer allocate_uniform_buffer(VkDescriptorSet descriptor_set, DescriptorBinding &binding);
 
-        void free_allocation(const UniformVariable &var, MemoryPool &memory);
+        void free_allocation(const UniformVariable &var);
 
       public:
-        UniformRegistry(VkDevice device, const PhysicalDevice &physical, VkCommandPool transfer_pool);
-        UniformRegistry() = default;
+        UniformRegistry(VkDevice device,
+                        const PhysicalDevice &physical,
+                        MemoryPool &memory,
+                        VkCommandPool transfer_pool);
+        ~UniformRegistry();
 
-        DescriptorAllocation allocate(const DescriptorSet &set, MemoryPool &memory);
+        DescriptorAllocation allocate(const DescriptorSet &set);
 
         PushConstantAllocation allocate(const PushConstant &push_constant);
 
@@ -92,8 +95,6 @@ namespace Dynamo::Graphics::Vulkan {
 
         void bind(Uniform uniform, const TextureInstance &texture, unsigned index);
 
-        void destroy(Uniform uniform, MemoryPool &memory);
-
-        void destroy(MemoryPool &memory);
+        void destroy(Uniform uniform);
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/Utils.cpp
+++ b/src/Graphics/Vulkan/Utils.cpp
@@ -1,5 +1,5 @@
 #include <Graphics/Vulkan/Utils.hpp>
-#include <vulkan/vulkan_core.h>
+#include <fstream>
 
 static PFN_vkCreateDebugUtilsMessengerEXT vkCreateDebuggerDispatch;
 static PFN_vkDestroyDebugUtilsMessengerEXT vkDestroyDebuggerDispatch;
@@ -1572,6 +1572,26 @@ namespace Dynamo::Graphics::Vulkan {
         VkResult result = vkCreateRenderPass(device, &renderpass_info, nullptr, &renderpass);
         VkResult_check("Create Render Pass", result);
         return renderpass;
+    }
+
+    VkPipelineCache VkPipelineCache_create(VkDevice device, const std::string &filename) {
+        std::ifstream ifstream;
+        ifstream.open(filename, std::ios::app | std::ios::binary);
+        ifstream.seekg(0, ifstream.end);
+        size_t size = ifstream.tellg();
+        ifstream.seekg(0, ifstream.beg);
+        std::vector<char> buffer(size);
+        ifstream.read(buffer.data(), size);
+        ifstream.close();
+
+        VkPipelineCacheCreateInfo cache_info;
+        cache_info.sType = VK_STRUCTURE_TYPE_PIPELINE_CACHE_CREATE_INFO;
+        cache_info.initialDataSize = size;
+        cache_info.pInitialData = buffer.data();
+
+        VkPipelineCache cache;
+        VkResult_check("Create Pipeline Cache", vkCreatePipelineCache(device, &cache_info, nullptr, &cache));
+        return cache;
     }
 
     VkPipeline VkPipeline_create(VkDevice device,

--- a/src/Graphics/Vulkan/Utils.hpp
+++ b/src/Graphics/Vulkan/Utils.hpp
@@ -116,6 +116,8 @@ namespace Dynamo::Graphics::Vulkan {
                                      VkFormat color_format,
                                      VkFormat depth_stencil_format);
 
+    VkPipelineCache VkPipelineCache_create(VkDevice device, const std::string &filename);
+
     VkPipeline VkPipeline_create(VkDevice device,
                                  VkPipelineCache cache,
                                  VkPipelineLayout layout,

--- a/src/Graphics/Vulkan/VulkanContext.cpp
+++ b/src/Graphics/Vulkan/VulkanContext.cpp
@@ -1,0 +1,27 @@
+#include <Graphics/Vulkan/Utils.hpp>
+#include <Graphics/Vulkan/VulkanContext.hpp>
+
+namespace Dynamo::Graphics::Vulkan {
+    VulkanContext::VulkanContext(const Display &display) :
+        instance(VkInstance_create(display)),
+#ifdef DYN_DEBUG
+        debugger(VkDebugUtilsMessengerEXT_create(instance)),
+#endif
+        surface(display.create_vulkan_surface(instance)),
+        physical(PhysicalDevice::select_best(instance, surface)),
+        device(VkDevice_create(physical)),
+        graphics_pool(VkCommandPool_create(device, physical.graphics_queues)),
+        transfer_pool(VkCommandPool_create(device, physical.transfer_queues)) {
+    }
+
+    VulkanContext::~VulkanContext() {
+        vkDestroyCommandPool(device, graphics_pool, nullptr);
+        vkDestroyCommandPool(device, transfer_pool, nullptr);
+        vkDestroyDevice(device, nullptr);
+        vkDestroySurfaceKHR(instance, surface, nullptr);
+#ifdef DYN_DEBUG
+        vkDestroyDebugUtilsMessengerEXT(instance, debugger, nullptr);
+#endif
+        vkDestroyInstance(instance, nullptr);
+    }
+} // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/VulkanContext.hpp
+++ b/src/Graphics/Vulkan/VulkanContext.hpp
@@ -1,0 +1,23 @@
+#pragma once
+
+#include <vulkan/vulkan_core.h>
+
+#include <Display.hpp>
+#include <Graphics/Vulkan/PhysicalDevice.hpp>
+
+namespace Dynamo::Graphics::Vulkan {
+    struct VulkanContext {
+        VkInstance instance;
+        VkDebugUtilsMessengerEXT debugger;
+        VkSurfaceKHR surface;
+
+        PhysicalDevice physical;
+        VkDevice device;
+
+        VkCommandPool graphics_pool;
+        VkCommandPool transfer_pool;
+
+        VulkanContext(const Display &display);
+        ~VulkanContext();
+    };
+} // namespace Dynamo::Graphics::Vulkan

--- a/src/Utils/Allocator.cpp
+++ b/src/Utils/Allocator.cpp
@@ -11,7 +11,7 @@ namespace Dynamo {
     }
 
     void Allocator::defragment(std::list<Block>::iterator it) {
-#ifdef DYN_DEBUG
+#if defined(DYN_DEBUG) && defined(DYN_DEBUG_ALLOCATOR)
         Log::info("Defragmentation target: {} {}", it->offset, it->offset + it->size);
         Log::info("Before defragmentation: {}", print());
 #endif
@@ -39,7 +39,7 @@ namespace Dynamo {
         it->offset = new_offset;
         it->size = new_size;
 
-#ifdef DYN_DEBUG
+#if defined(DYN_DEBUG) && defined(DYN_DEBUG_ALLOCATOR)
         Log::info("After defragmentation: {}", print());
 #endif
     }
@@ -131,7 +131,7 @@ namespace Dynamo {
     }
 
     void Allocator::grow(unsigned capacity) {
-#ifdef DYN_DEBUG
+#if defined(DYN_DEBUG) && defined(DYN_DEBUG_ALLOCATOR)
         Log::info("Before grow: {}", print());
 #endif
         DYN_ASSERT(capacity >= _capacity);
@@ -147,7 +147,7 @@ namespace Dynamo {
         _free.push_back(new_free);
         defragment(std::prev(_free.end()));
 
-#ifdef DYN_DEBUG
+#if defined(DYN_DEBUG) && defined(DYN_DEBUG_ALLOCATOR)
         Log::info("After grow: {}", print());
 #endif
     }

--- a/src/Utils/Allocator.hpp
+++ b/src/Utils/Allocator.hpp
@@ -5,6 +5,9 @@
 #include <string>
 #include <unordered_map>
 
+// Enable this to visualize heap growth and defragmentation behavior
+// #define DEBUG_ALLOCATOR
+
 namespace Dynamo {
     /**
      * @brief Round up a size to be a multiple of alignment.


### PR DESCRIPTION
* Add destructors to replace "destroy()" calls
* Implement RenderContext to hold core Vulkan objects
* Add DEBUG_ALLOCATOR #define to toggle Allocator debug printing
* Update code linter