### PR TITLE
Fix Vulkan device memory overallocation

### DIFF
--- a/src/Graphics/Vulkan/MemoryPool.cpp
+++ b/src/Graphics/Vulkan/MemoryPool.cpp
@@ -3,6 +3,9 @@
 #include <Utils/Log.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
+    // We only have 4096 guaranteed allocations. 32M * 4096 is over 100GB, so this should be enough.
+    constexpr VkDeviceSize MIN_ALLOCATION_SIZE = 32 * (1 << 20);
+
     MemoryPool::MemoryPool(VkDevice device, const PhysicalDevice &physical) :
         _device(device),
         _physical(physical),
@@ -36,53 +39,63 @@ namespace Dynamo::Graphics::Vulkan {
 
     MemoryPool::VirtualMemory MemoryPool::allocate_memory(const VkMemoryRequirements &requirements,
                                                           VkMemoryPropertyFlags properties) {
-        VirtualMemory allocation;
-        allocation.key.type = find_type_index(requirements, properties);
-        allocation.mapped = nullptr;
-
-        MemoryGroup &group = _groups[allocation.key.type];
-        for (allocation.key.index = 0; allocation.key.index < group.size(); allocation.key.index++) {
-            Memory &memory = group[allocation.key.index];
+        // Find compatible memory block and suballocate
+        unsigned type = find_type_index(requirements, properties);
+        MemoryGroup &group = _groups[type];
+        for (unsigned index = 0; index < group.size(); index++) {
+            Memory &memory = group[index];
+            char *base_ptr = static_cast<char *>(memory.mapped);
 
             std::optional<unsigned> result = memory.allocator.reserve(requirements.size, requirements.alignment);
             if (result.has_value()) {
-                allocation.memory = memory.handle;
+                VirtualMemory allocation;
+                allocation.key.type = type;
+                allocation.key.index = index;
                 allocation.key.offset = result.value();
-                if (memory.mapped) {
-                    allocation.mapped = static_cast<char *>(memory.mapped) + allocation.key.offset;
+                allocation.memory = memory.handle;
+                allocation.mapped = nullptr;
+                if (base_ptr) {
+                    allocation.mapped = base_ptr + allocation.key.offset;
                 }
+                return allocation;
             }
         }
 
-        // None found, allocate new memory
-        VkDeviceSize heap_size = std::max(requirements.size, MEMORY_ALLOCATION_SIZE);
-        allocation.memory = VkDeviceMemory_allocate(_device, allocation.key.type, heap_size);
+        // None found, build new memory block and suballocate
+        VkDeviceSize heap_size = std::max(requirements.size, MIN_ALLOCATION_SIZE);
+        VkDeviceMemory memory = VkDeviceMemory_allocate(_device, type, heap_size);
+        void *mapped = nullptr;
         if (properties & VK_MEMORY_PROPERTY_HOST_VISIBLE_BIT) {
-            VkResult_check("Map Memory", vkMapMemory(_device, allocation.memory, 0, heap_size, 0, &allocation.mapped));
+            VkResult_check("Map Memory", vkMapMemory(_device, memory, 0, heap_size, 0, &mapped));
         }
-        group.push_back({allocation.memory, heap_size, allocation.mapped});
+        group.push_back({memory, heap_size, mapped});
 
-        Memory &memory = group.back();
-        allocation.key.offset = memory.allocator.reserve(requirements.size, requirements.alignment).value();
+        VirtualMemory allocation;
+        allocation.key.type = type;
+        allocation.key.index = group.size() - 1;
+        allocation.key.offset = group.back().allocator.reserve(requirements.size, requirements.alignment).value();
+        allocation.memory = memory;
+        allocation.mapped = mapped;
         return allocation;
     }
 
     VirtualBuffer MemoryPool::build(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, unsigned size) {
         // Create the buffer
-        VirtualBuffer buffer;
-        buffer.buffer = VkBuffer_create(_device, usage, size, nullptr, 0);
+        VkBuffer buffer = VkBuffer_create(_device, usage, size, nullptr, 0);
 
         // Allocate memory and bind to buffer
         VkMemoryRequirements requirements;
-        vkGetBufferMemoryRequirements(_device, buffer.buffer, &requirements);
+        vkGetBufferMemoryRequirements(_device, buffer, &requirements);
 
         VirtualMemory memory = allocate_memory(requirements, properties);
-        buffer.key = memory.key;
-        buffer.offset = 0; // TODO: Suballocation
-        buffer.mapped = memory.mapped;
+        vkBindBufferMemory(_device, buffer, memory.memory, memory.key.offset);
 
-        vkBindBufferMemory(_device, buffer.buffer, memory.memory, buffer.offset);
-        return buffer;
+        VirtualBuffer v_buffer;
+        v_buffer.buffer = buffer;
+        v_buffer.key = memory.key;
+        v_buffer.offset = 0; // TODO: Suballocation
+        v_buffer.mapped = memory.mapped;
+        return v_buffer;
     }
 
     VirtualImage MemoryPool::build(const VkExtent3D &extent,
@@ -96,31 +109,32 @@ namespace Dynamo::Graphics::Vulkan {
                                    unsigned mip_levels,
                                    unsigned array_layers) {
         // Create the image
-        VirtualImage image;
-        image.image = VkImage_create(_device,
-                                     extent,
-                                     format,
-                                     layout,
-                                     type,
-                                     tiling,
-                                     usage,
-                                     samples,
-                                     flags,
-                                     mip_levels,
-                                     array_layers,
-                                     nullptr,
-                                     0);
+        VkImage image = VkImage_create(_device,
+                                       extent,
+                                       format,
+                                       layout,
+                                       type,
+                                       tiling,
+                                       usage,
+                                       samples,
+                                       flags,
+                                       mip_levels,
+                                       array_layers,
+                                       nullptr,
+                                       0);
 
         // Allocate memory and bind to image
         VkMemoryRequirements requirements;
-        vkGetImageMemoryRequirements(_device, image.image, &requirements);
+        vkGetImageMemoryRequirements(_device, image, &requirements);
 
         VirtualMemory memory = allocate_memory(requirements, VK_MEMORY_PROPERTY_DEVICE_LOCAL_BIT);
-        image.key = memory.key;
-        image.mapped = memory.mapped;
+        vkBindImageMemory(_device, image, memory.memory, memory.key.offset);
 
-        vkBindImageMemory(_device, image.image, memory.memory, image.key.offset);
-        return image;
+        VirtualImage v_image;
+        v_image.image = image;
+        v_image.key = memory.key;
+        v_image.mapped = memory.mapped;
+        return v_image;
     }
 
     void MemoryPool::free(const VirtualBuffer &allocation) {

--- a/src/Graphics/Vulkan/MemoryPool.hpp
+++ b/src/Graphics/Vulkan/MemoryPool.hpp
@@ -7,9 +7,6 @@
 #include <Utils/Allocator.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    // We only have 4096 guaranteed allocations. 32M * 4096 is over 100GB, so this should be enough.
-    constexpr VkDeviceSize MEMORY_ALLOCATION_SIZE = 32 * (1 << 20);
-
     struct AllocationKey {
         unsigned offset;
         unsigned type;

--- a/src/Graphics/Vulkan/PhysicalDevice.cpp
+++ b/src/Graphics/Vulkan/PhysicalDevice.cpp
@@ -108,9 +108,9 @@ namespace Dynamo::Graphics::Vulkan {
         }
 
         Log::info("Selecting Vulkan device:");
-        PhysicalDevice best = PhysicalDevice(handles[0], surface);
+        PhysicalDevice best(handles[0], surface);
         for (unsigned i = 0; i < handles.size(); i++) {
-            PhysicalDevice device = PhysicalDevice(handles[i], surface);
+            PhysicalDevice device(handles[i], surface);
             unsigned score = device.score();
             if (score > best.score()) {
                 best = device;

--- a/src/Utils/VirtualMemory.cpp
+++ b/src/Utils/VirtualMemory.cpp
@@ -2,30 +2,25 @@
 #include <Utils/VirtualMemory.hpp>
 
 namespace Dynamo {
-    VirtualMemory::VirtualMemory(unsigned initial_size, unsigned alignment) :
-        _buffer(initial_size), _allocator(initial_size), _alignment(alignment) {}
+    VirtualMemory::VirtualMemory(unsigned capacity, unsigned alignment) :
+        _buffer(capacity),
+        _allocator(capacity),
+        _alignment(alignment) {}
+
+    unsigned VirtualMemory::capacity() const { return _allocator.capacity(); }
 
     unsigned VirtualMemory::size(unsigned block_offset) const { return _allocator.size(block_offset); }
 
-    unsigned VirtualMemory::reserve(unsigned size) {
-        std::optional<unsigned> result = _allocator.reserve(size, _alignment);
-        if (result.has_value()) {
-            return result.value();
-        } else {
-            unsigned curr = _allocator.capacity();
-            unsigned next = std::max(curr + size, curr * 2);
-            unsigned next_aligned = align_size(next, _alignment);
-            _allocator.grow(next_aligned);
-            _buffer.resize(next_aligned);
+    std::optional<unsigned> VirtualMemory::reserve(unsigned size) { return _allocator.reserve(size, _alignment); }
 
-            // If this fails, we're in trouble...
-            return _allocator.reserve(size, _alignment).value();
-        }
+    void VirtualMemory::grow(unsigned capacity) {
+        _allocator.grow(capacity);
+        _buffer.resize(capacity);
     }
 
     void VirtualMemory::free(unsigned block_offset) { _allocator.free(block_offset); }
 
-    void *VirtualMemory::get_mapped(unsigned block_offset) {
+    void *VirtualMemory::mapped(unsigned block_offset) {
         DYN_ASSERT(_allocator.is_reserved(block_offset));
         return _buffer.data() + block_offset;
     }

--- a/src/Utils/VirtualMemory.hpp
+++ b/src/Utils/VirtualMemory.hpp
@@ -15,8 +15,14 @@ namespace Dynamo {
         unsigned _alignment;
 
       public:
-        VirtualMemory(unsigned initial_size, unsigned alignment = 1);
-        VirtualMemory() = default;
+        VirtualMemory(unsigned capacity, unsigned alignment = 1);
+
+        /**
+         * @brief Get the capacity of the heap.
+         *
+         * @return unsigned
+         */
+        unsigned capacity() const;
 
         /**
          * @brief Get the size of a block.
@@ -30,9 +36,16 @@ namespace Dynamo {
          * @brief Reserve a block.
          *
          * @param size
-         * @return unsigned
+         * @return std::optional<unsigned>
          */
-        unsigned reserve(unsigned size);
+        std::optional<unsigned> reserve(unsigned size);
+
+        /**
+         * @brief Grow the heap.
+         *
+         * @param capacity
+         */
+        void grow(unsigned capacity);
 
         /**
          * @brief Free an allocated block.
@@ -46,6 +59,6 @@ namespace Dynamo {
          *
          * @return void*
          */
-        void *get_mapped(unsigned block_offset);
+        void *mapped(unsigned block_offset);
     };
 } // namespace Dynamo

--- a/tests/src/Utils/VirtualMemory.cpp
+++ b/tests/src/Utils/VirtualMemory.cpp
@@ -4,21 +4,31 @@
 TEST_CASE("VirtualMemory reserve", "[VirtualMemory]") {
     Dynamo::VirtualMemory memory(256, 4);
     memory.reserve(3);
-    unsigned offset = memory.reserve(12);
+    unsigned offset = memory.reserve(12).value();
 
     REQUIRE(offset == 4);
     REQUIRE(memory.size(offset) == 12);
-    REQUIRE(memory.get_mapped(offset) != nullptr);
+    REQUIRE(memory.mapped(offset) != nullptr);
+    REQUIRE_THROWS(memory.reserve(1024).value());
 }
 
 TEST_CASE("VirtualMemory free", "[VirtualMemory]") {
     Dynamo::VirtualMemory memory(256, 4);
-    unsigned offset = memory.reserve(3);
+    unsigned offset = memory.reserve(3).value();
 
     REQUIRE(offset == 0);
     REQUIRE(memory.size(offset) == 3);
-    REQUIRE(memory.get_mapped(offset) != nullptr);
+    REQUIRE(memory.mapped(offset) != nullptr);
 
     memory.free(offset);
     REQUIRE_THROWS(memory.size(offset));
+}
+
+TEST_CASE("VirtualMemory grow", "[VirtualMemory]") {
+    Dynamo::VirtualMemory memory(256, 4);
+    memory.reserve(3).value();
+    memory.grow(2048);
+
+    REQUIRE(memory.capacity() == 2048);
+    REQUIRE_NOTHROW(memory.reserve(1024).value());
 }


### PR DESCRIPTION
* Implement VirtualMemory::capacity() and grow()
* Rename VirtualMemory::get_mapped() to mapped()