### PR TITLE
Revamp UniformRegistry and decouple descriptor set management

### DIFF
--- a/src/Graphics/Renderer.hpp
+++ b/src/Graphics/Renderer.hpp
@@ -6,6 +6,7 @@
 #include <Graphics/Mesh.hpp>
 #include <Graphics/Model.hpp>
 #include <Graphics/Texture.hpp>
+#include <Graphics/Vulkan/DescriptorPool.hpp>
 #include <Graphics/Vulkan/FrameContext.hpp>
 #include <Graphics/Vulkan/MeshRegistry.hpp>
 #include <Graphics/Vulkan/PhysicalDevice.hpp>
@@ -28,6 +29,7 @@ namespace Dynamo::Graphics {
         Vulkan::Swapchain _swapchain;
 
         Vulkan::MemoryPool _memory;
+        Vulkan::DescriptorPool _descriptors;
         Vulkan::MeshRegistry _meshes;
         Vulkan::ShaderRegistry _shaders;
         Vulkan::PipelineRegistry _pipelines;
@@ -45,9 +47,17 @@ namespace Dynamo::Graphics {
         std::vector<Model> _models;
 
         // Important TODO:
+        // * Proper render pass system to implement algorithms like Forward+
+        //      - Allow creating render passes at the user level
+        //      - Users can specify number of color attachments and types
+        //      - Users should have control over the render target area
+        //      - Users should have control over which textures to use as attachments
+        //      - Users should have control over attachment clear values
+        //      - Revamp render() workflow, need to arbitrarily begin and end renderpasses
         // * Draw-to-texture?
         // * Decouple Uniform allocation from Pipeline?
-        //      - Pipeline creation is expensive since we need to hash the descriptors (these are huge)
+        //      - Pipeline creation is expensive since we need to hash the layout and pipeline descriptors
+        //      - Those are huge structs, computing them for each object created will be super slow
         //      - Pipeline should be a Pipeline/Layout pair + metadata for uniform allocation
         //      - Uniforms are quicker to allocate
         // * Customizable color blending (do we really need this?)

--- a/src/Graphics/Vulkan/DescriptorPool.cpp
+++ b/src/Graphics/Vulkan/DescriptorPool.cpp
@@ -1,0 +1,62 @@
+#include <Graphics/Vulkan/DescriptorPool.hpp>
+#include <Graphics/Vulkan/Utils.hpp>
+
+namespace Dynamo::Graphics::Vulkan {
+    // Descriptor pool sizes, need to balance this for time spent allocating vs memory usage
+    constexpr unsigned DESCRIPTOR_POOL_SIZE = 1024;
+    constexpr std::array<VkDescriptorPoolSize, 2> DESCRIPTOR_TYPE_SIZES = {
+        VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER, DESCRIPTOR_POOL_SIZE},
+        VkDescriptorPoolSize{VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER, DESCRIPTOR_POOL_SIZE},
+    };
+
+    DescriptorPool::DescriptorPool(VkDevice device) : _device(device) {}
+
+    DescriptorPool::~DescriptorPool() {
+        // Destroy descriptor pools
+        for (const auto &[layout, cache] : _pools) {
+            for (const VkDescriptorPool pool : cache.pools) {
+                vkDestroyDescriptorPool(_device, pool, nullptr);
+            }
+        }
+        _pools.clear();
+    }
+
+    VirtualDescriptorSet DescriptorPool::allocate_descriptor_set(VkDescriptorSetLayout layout) {
+        DescriptorPoolCache &pool_cache = _pools[layout];
+
+        // Check if we can reuse a descriptor set
+        if (pool_cache.inactive.size()) {
+            VirtualDescriptorSet set = pool_cache.inactive.back();
+            pool_cache.inactive.pop_back();
+            return set;
+        }
+
+        // Allocate a new descriptor set from a pool
+        for (VkDescriptorPool &pool : pool_cache.pools) {
+            try {
+                VirtualDescriptorSet set;
+                set.layout = layout;
+                VkDescriptorSet_allocate(_device, pool, &layout, &set.set, 1);
+                return set;
+            } catch (std::exception &e) {
+            }
+        }
+
+        // Pools are full, so create a new one
+        VkDescriptorPool pool = VkDescriptorPool_create(_device,
+                                                        DESCRIPTOR_TYPE_SIZES.data(),
+                                                        DESCRIPTOR_TYPE_SIZES.size(),
+                                                        DESCRIPTOR_POOL_SIZE);
+        pool_cache.pools.push_back(pool);
+
+        VirtualDescriptorSet set;
+        set.layout = layout;
+        VkDescriptorSet_allocate(_device, pool, &layout, &set.set, 1);
+        return set;
+    }
+
+    void DescriptorPool::free_descriptor_set(const VirtualDescriptorSet &set) {
+        // Mark the set for recycling
+        _pools.at(set.layout).inactive.push_back(set);
+    }
+} // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/DescriptorPool.hpp
+++ b/src/Graphics/Vulkan/DescriptorPool.hpp
@@ -1,0 +1,32 @@
+#pragma once
+
+#include <unordered_map>
+#include <vector>
+
+#include <vulkan/vulkan_core.h>
+
+namespace Dynamo::Graphics::Vulkan {
+    struct VirtualDescriptorSet {
+        VkDescriptorSetLayout layout;
+        VkDescriptorSet set;
+    };
+
+    struct DescriptorPoolCache {
+        std::vector<VkDescriptorPool> pools;
+        std::vector<VirtualDescriptorSet> inactive;
+    };
+
+    class DescriptorPool {
+        VkDevice _device;
+
+        std::unordered_map<VkDescriptorSetLayout, DescriptorPoolCache> _pools;
+
+      public:
+        DescriptorPool(VkDevice device);
+        ~DescriptorPool();
+
+        VirtualDescriptorSet allocate_descriptor_set(VkDescriptorSetLayout layout);
+
+        void free_descriptor_set(const VirtualDescriptorSet &set);
+    };
+} // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/MemoryPool.cpp
+++ b/src/Graphics/Vulkan/MemoryPool.cpp
@@ -79,7 +79,8 @@ namespace Dynamo::Graphics::Vulkan {
         return allocation;
     }
 
-    VirtualBuffer MemoryPool::build(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, unsigned size) {
+    VirtualBuffer
+    MemoryPool::allocate_buffer(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, unsigned size) {
         // Create the buffer
         VkBuffer buffer = VkBuffer_create(_device, usage, size, nullptr, 0);
 
@@ -98,16 +99,16 @@ namespace Dynamo::Graphics::Vulkan {
         return v_buffer;
     }
 
-    VirtualImage MemoryPool::build(const VkExtent3D &extent,
-                                   VkFormat format,
-                                   VkImageLayout layout,
-                                   VkImageType type,
-                                   VkImageTiling tiling,
-                                   VkImageUsageFlags usage,
-                                   VkSampleCountFlagBits samples,
-                                   VkImageCreateFlags flags,
-                                   unsigned mip_levels,
-                                   unsigned array_layers) {
+    VirtualImage MemoryPool::allocate_image(const VkExtent3D &extent,
+                                            VkFormat format,
+                                            VkImageLayout layout,
+                                            VkImageType type,
+                                            VkImageTiling tiling,
+                                            VkImageUsageFlags usage,
+                                            VkSampleCountFlagBits samples,
+                                            VkImageCreateFlags flags,
+                                            unsigned mip_levels,
+                                            unsigned array_layers) {
         // Create the image
         VkImage image = VkImage_create(_device,
                                        extent,
@@ -137,13 +138,13 @@ namespace Dynamo::Graphics::Vulkan {
         return v_image;
     }
 
-    void MemoryPool::free(const VirtualBuffer &allocation) {
+    void MemoryPool::free_buffer(const VirtualBuffer &allocation) {
         vkDestroyBuffer(_device, allocation.buffer, nullptr);
         Memory &memory = _groups[allocation.key.type][allocation.key.index];
         memory.allocator.free(allocation.key.offset);
     }
 
-    void MemoryPool::free(const VirtualImage &allocation) {
+    void MemoryPool::free_image(const VirtualImage &allocation) {
         vkDestroyImage(_device, allocation.image, nullptr);
         Memory &memory = _groups[allocation.key.type][allocation.key.index];
         memory.allocator.free(allocation.key.offset);

--- a/src/Graphics/Vulkan/MemoryPool.hpp
+++ b/src/Graphics/Vulkan/MemoryPool.hpp
@@ -51,21 +51,21 @@ namespace Dynamo::Graphics::Vulkan {
         MemoryPool(VkDevice device, const PhysicalDevice &physical);
         ~MemoryPool();
 
-        VirtualBuffer build(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, unsigned size);
+        VirtualBuffer allocate_buffer(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, unsigned size);
 
-        VirtualImage build(const VkExtent3D &extent,
-                           VkFormat format,
-                           VkImageLayout layout,
-                           VkImageType type,
-                           VkImageTiling tiling,
-                           VkImageUsageFlags usage,
-                           VkSampleCountFlagBits samples,
-                           VkImageCreateFlags flags,
-                           unsigned mip_levels,
-                           unsigned array_layers);
+        VirtualImage allocate_image(const VkExtent3D &extent,
+                                    VkFormat format,
+                                    VkImageLayout layout,
+                                    VkImageType type,
+                                    VkImageTiling tiling,
+                                    VkImageUsageFlags usage,
+                                    VkSampleCountFlagBits samples,
+                                    VkImageCreateFlags flags,
+                                    unsigned mip_levels,
+                                    unsigned array_layers);
 
-        void free(const VirtualBuffer &allocation);
+        void free_buffer(const VirtualBuffer &allocation);
 
-        void free(const VirtualImage &allocation);
+        void free_image(const VirtualImage &allocation);
     };
 }; // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/PipelineRegistry.hpp
+++ b/src/Graphics/Vulkan/PipelineRegistry.hpp
@@ -15,16 +15,16 @@
 
 namespace Dynamo::Graphics::Vulkan {
     struct PipelineLayoutSettings {
-        std::vector<VkDescriptorSetLayout> descriptor_layouts;
+        std::vector<VkDescriptorSetLayout> descriptor_set_layouts;
         std::vector<VkPushConstantRange> push_constant_ranges;
 
         inline bool operator==(const PipelineLayoutSettings &other) const {
-            if (descriptor_layouts.size() != other.descriptor_layouts.size() ||
+            if (descriptor_set_layouts.size() != other.descriptor_set_layouts.size() ||
                 push_constant_ranges.size() != other.push_constant_ranges.size()) {
                 return false;
             }
-            for (unsigned i = 0; i < descriptor_layouts.size(); i++) {
-                if (descriptor_layouts[i] != other.descriptor_layouts[i]) {
+            for (unsigned i = 0; i < descriptor_set_layouts.size(); i++) {
+                if (descriptor_set_layouts[i] != other.descriptor_set_layouts[i]) {
                     return false;
                 }
             }
@@ -42,8 +42,8 @@ namespace Dynamo::Graphics::Vulkan {
         struct Hash {
             inline size_t operator()(const PipelineLayoutSettings &settings) const {
                 size_t hash_base = 0;
-                for (unsigned i = 0; i < settings.descriptor_layouts.size(); i++) {
-                    VkDescriptorSetLayout layout = settings.descriptor_layouts[i];
+                for (unsigned i = 0; i < settings.descriptor_set_layouts.size(); i++) {
+                    VkDescriptorSetLayout layout = settings.descriptor_set_layouts[i];
                     size_t hash = std::hash<VkDescriptorSetLayout>{}(layout);
                     hash_base ^= (hash << i);
                 }
@@ -102,10 +102,7 @@ namespace Dynamo::Graphics::Vulkan {
     struct PipelineInstance {
         VkPipelineLayout layout;
         VkPipeline handle;
-        std::vector<Uniform> uniforms;
-        std::vector<VkDescriptorSet> descriptor_sets;
-        std::vector<VkPushConstantRange> push_constant_ranges;
-        std::vector<unsigned> push_constant_offsets;
+        UniformGroup uniform_group;
     };
 
     class PipelineRegistry {

--- a/src/Graphics/Vulkan/ShaderRegistry.hpp
+++ b/src/Graphics/Vulkan/ShaderRegistry.hpp
@@ -11,10 +11,10 @@
 #include <Utils/SparseArray.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    struct DescriptorLayoutKey {
+    struct DescriptorSetLayoutKey {
         std::vector<VkDescriptorSetLayoutBinding> bindings;
 
-        inline bool operator==(const DescriptorLayoutKey &other) const {
+        inline bool operator==(const DescriptorSetLayoutKey &other) const {
             // Descriptor set layouts are compatible as long as bindings are the same
             if (bindings.size() != other.bindings.size()) {
                 return false;
@@ -33,7 +33,7 @@ namespace Dynamo::Graphics::Vulkan {
         }
 
         struct Hash {
-            inline size_t operator()(const DescriptorLayoutKey &layout) const {
+            inline size_t operator()(const DescriptorSetLayoutKey &layout) const {
                 size_t hash_base = 0;
                 for (const VkDescriptorSetLayoutBinding &binding : layout.bindings) {
                     size_t hash0 = std::hash<unsigned>{}(binding.binding);
@@ -59,14 +59,14 @@ namespace Dynamo::Graphics::Vulkan {
         bool shared;
     };
 
-    struct DescriptorSet {
-        VkDescriptorSetLayout layout;
+    struct DescriptorSetLayout {
+        VkDescriptorSetLayout handle;
         std::vector<DescriptorBinding> bindings;
     };
 
-    struct PushConstant {
+    struct PushConstantRange {
         std::string name;
-        VkPushConstantRange range;
+        VkPushConstantRange block;
         bool shared;
     };
 
@@ -74,14 +74,14 @@ namespace Dynamo::Graphics::Vulkan {
         VkShaderModule handle;
         std::vector<VkVertexInputBindingDescription> bindings;
         std::vector<VkVertexInputAttributeDescription> attributes;
-        std::vector<DescriptorSet> descriptor_sets;
-        std::vector<PushConstant> push_constants;
+        std::vector<DescriptorSetLayout> descriptor_set_layouts;
+        std::vector<PushConstantRange> push_constant_ranges;
     };
 
     class ShaderRegistry {
         VkDevice _device;
         SparseArray<Shader, ShaderModule> _modules;
-        std::unordered_map<DescriptorLayoutKey, VkDescriptorSetLayout, DescriptorLayoutKey::Hash> _descriptor_layouts;
+        std::unordered_map<DescriptorSetLayoutKey, VkDescriptorSetLayout, DescriptorSetLayoutKey::Hash> _layouts;
 
         std::vector<uint32_t>
         compile(const std::string &name, const std::string &code, VkShaderStageFlagBits stage, bool optimized);

--- a/src/Graphics/Vulkan/UniformRegistry.hpp
+++ b/src/Graphics/Vulkan/UniformRegistry.hpp
@@ -5,6 +5,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include <Graphics/Texture.hpp>
+#include <Graphics/Vulkan/DescriptorPool.hpp>
 #include <Graphics/Vulkan/FrameContext.hpp>
 #include <Graphics/Vulkan/MemoryPool.hpp>
 #include <Graphics/Vulkan/ShaderRegistry.hpp>
@@ -13,6 +14,9 @@
 #include <Utils/VirtualMemory.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
+    // Uniform group handle
+    DYN_DEFINE_ID_TYPE(UniformGroup);
+
     // In Vulkan, uniform variables can be from a descriptor or push constant.
     // Renderer API should be able to access both types with the same API.
     enum class UniformType {
@@ -20,7 +24,17 @@ namespace Dynamo::Graphics::Vulkan {
         PushConstant,
     };
 
-    struct DescriptorData {
+    struct SharedDescriptor {
+        unsigned ref_count;
+        VirtualBuffer buffer;
+    };
+
+    struct SharedPushConstant {
+        unsigned ref_count;
+        unsigned offset;
+    };
+
+    struct Descriptor {
         VirtualBuffer buffer;
         VkDescriptorType type;
         VkDescriptorSet set;
@@ -29,65 +43,62 @@ namespace Dynamo::Graphics::Vulkan {
         unsigned count;
     };
 
-    struct PushConstantData {
+    struct PushConstant {
         unsigned offset;
         unsigned size;
     };
 
-    struct UniformVariable {
+    struct UniformGroupInstance {
+        std::vector<Uniform> uniforms;
+        std::vector<VirtualDescriptorSet> v_sets;
+        std::vector<VkDescriptorSet> descriptor_sets;
+        std::vector<VkPushConstantRange> push_constant_ranges;
+        std::vector<unsigned> push_constant_offsets;
+    };
+
+    struct UniformInstance {
         std::string name;
         UniformType type;
         union {
-            DescriptorData descriptor;
-            PushConstantData push_constant;
+            Descriptor descriptor;
+            PushConstant push_constant;
         };
-    };
-
-    // Ref-counted shared allocation information
-    struct SharedVariable {
-        unsigned ref_count;
-        union {
-            VirtualBuffer descriptor_buffer;
-            unsigned push_constant_offset;
-        };
-    };
-
-    struct DescriptorAllocation {
-        VkDescriptorSet descriptor_set;
-        std::vector<Uniform> uniforms;
-    };
-
-    struct PushConstantAllocation {
-        Uniform uniform;
-        VkPushConstantRange range;
-        unsigned block_offset;
     };
 
     class UniformRegistry {
         VkDevice _device;
-        VkDescriptorPool _pool;
         MemoryPool &_memory;
+        DescriptorPool &_descriptors;
         VirtualMemory _push_constant_buffer;
 
-        std::unordered_map<std::string, SharedVariable> _shared;
-        SparseArray<Uniform, UniformVariable> _variables;
+        std::unordered_map<std::string, SharedDescriptor> _shared_descriptors;
+        std::unordered_map<std::string, SharedPushConstant> _shared_push_constants;
 
-        VirtualBuffer allocate_uniform_buffer(VkDescriptorSet descriptor_set, DescriptorBinding &binding);
+        SparseArray<UniformGroup, UniformGroupInstance> _groups;
+        SparseArray<Uniform, UniformInstance> _uniforms;
 
-        void free_allocation(const UniformVariable &var);
+        VirtualBuffer allocate_descriptor_binding(VkDescriptorSet set, const DescriptorBinding &binding);
+
+        unsigned allocate_push_constant_range(const PushConstantRange &range);
+
+        void free_uniform(const UniformInstance &var);
+
+        void free_group(const UniformGroupInstance &group);
 
       public:
         UniformRegistry(VkDevice device,
                         const PhysicalDevice &physical,
                         MemoryPool &memory,
+                        DescriptorPool &descriptors,
                         VkCommandPool transfer_pool);
         ~UniformRegistry();
 
-        DescriptorAllocation allocate(const DescriptorSet &set);
+        UniformGroup build(const std::vector<const DescriptorSetLayout *> &descriptor_set_layouts,
+                           const std::vector<const PushConstantRange *> &push_constant_ranges);
 
-        PushConstantAllocation allocate(const PushConstant &push_constant);
+        const UniformGroupInstance &get(UniformGroup group) const;
 
-        const UniformVariable &get(Uniform uniform);
+        std::optional<Uniform> find(UniformGroup group, const std::string &uniform_name) const;
 
         void *get_push_constant_data(unsigned block_offset);
 
@@ -95,6 +106,6 @@ namespace Dynamo::Graphics::Vulkan {
 
         void bind(Uniform uniform, const TextureInstance &texture, unsigned index);
 
-        void destroy(Uniform uniform);
+        void destroy(UniformGroup group);
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/Utils.cpp
+++ b/src/Graphics/Vulkan/Utils.cpp
@@ -1795,8 +1795,10 @@ namespace Dynamo::Graphics::Vulkan {
         VkResult_check("Allocate Command Buffers", vkAllocateCommandBuffers(device, &alloc_info, dst));
     }
 
-    VkDescriptorPool
-    VkDescriptorPool_create(VkDevice device, VkDescriptorPoolSize *sizes, unsigned size_count, unsigned max_sets) {
+    VkDescriptorPool VkDescriptorPool_create(VkDevice device,
+                                             const VkDescriptorPoolSize *sizes,
+                                             unsigned size_count,
+                                             unsigned max_sets) {
         VkDescriptorPoolCreateInfo pool_info = {};
         pool_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_POOL_CREATE_INFO;
         pool_info.poolSizeCount = size_count;

--- a/src/Graphics/Vulkan/Utils.hpp
+++ b/src/Graphics/Vulkan/Utils.hpp
@@ -153,7 +153,7 @@ namespace Dynamo::Graphics::Vulkan {
                                   unsigned count);
 
     VkDescriptorPool
-    VkDescriptorPool_create(VkDevice device, VkDescriptorPoolSize *sizes, unsigned size_count, unsigned max_sets);
+    VkDescriptorPool_create(VkDevice device, const VkDescriptorPoolSize *sizes, unsigned size_count, unsigned max_sets);
 
     void VkDescriptorSet_allocate(VkDevice device,
                                   VkDescriptorPool pool,


### PR DESCRIPTION
* Allow descriptor pools to scale dynamically, recycling inactive descriptor sets
* Let descriptor set layouts be allocated uniquely for a given pipeline
* Allow descriptor sets and push constants to be shared across shader stages