### PR TITLE
Use Vulkan Context object in renderer submodules

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@ build
 .DS_Store
 .cache
 compile_commands.json
-vulkan-cache.bin
+vulkan_cache.bin

--- a/src/Graphics/Renderer.hpp
+++ b/src/Graphics/Renderer.hpp
@@ -6,6 +6,7 @@
 #include <Graphics/Mesh.hpp>
 #include <Graphics/Model.hpp>
 #include <Graphics/Texture.hpp>
+#include <Graphics/Vulkan/Context.hpp>
 #include <Graphics/Vulkan/DescriptorPool.hpp>
 #include <Graphics/Vulkan/FrameContext.hpp>
 #include <Graphics/Vulkan/MeshRegistry.hpp>
@@ -15,7 +16,6 @@
 #include <Graphics/Vulkan/Swapchain.hpp>
 #include <Graphics/Vulkan/TextureRegistry.hpp>
 #include <Graphics/Vulkan/UniformRegistry.hpp>
-#include <Graphics/Vulkan/VulkanContext.hpp>
 #include <Math/Color.hpp>
 
 namespace Dynamo::Graphics {
@@ -25,7 +25,7 @@ namespace Dynamo::Graphics {
      */
     class Renderer {
         const Display &_display;
-        Vulkan::VulkanContext _context;
+        Vulkan::Context _context;
         Vulkan::Swapchain _swapchain;
 
         Vulkan::MemoryPool _memory;

--- a/src/Graphics/Vulkan/Context.cpp
+++ b/src/Graphics/Vulkan/Context.cpp
@@ -1,8 +1,8 @@
+#include <Graphics/Vulkan/Context.hpp>
 #include <Graphics/Vulkan/Utils.hpp>
-#include <Graphics/Vulkan/VulkanContext.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    VulkanContext::VulkanContext(const Display &display) :
+    Context::Context(const Display &display) :
         instance(VkInstance_create(display)),
 #ifdef DYN_DEBUG
         debugger(VkDebugUtilsMessengerEXT_create(instance)),
@@ -12,9 +12,13 @@ namespace Dynamo::Graphics::Vulkan {
         device(VkDevice_create(physical)),
         graphics_pool(VkCommandPool_create(device, physical.graphics_queues)),
         transfer_pool(VkCommandPool_create(device, physical.transfer_queues)) {
+        vkGetDeviceQueue(device, physical.graphics_queues.index, 0, &graphics_queue);
+        vkGetDeviceQueue(device, physical.present_queues.index, 0, &present_queue);
+        vkGetDeviceQueue(device, physical.compute_queues.index, 0, &compute_queue);
+        vkGetDeviceQueue(device, physical.transfer_queues.index, 0, &transfer_queue);
     }
 
-    VulkanContext::~VulkanContext() {
+    Context::~Context() {
         vkDestroyCommandPool(device, graphics_pool, nullptr);
         vkDestroyCommandPool(device, transfer_pool, nullptr);
         vkDestroyDevice(device, nullptr);

--- a/src/Graphics/Vulkan/Context.hpp
+++ b/src/Graphics/Vulkan/Context.hpp
@@ -6,7 +6,7 @@
 #include <Graphics/Vulkan/PhysicalDevice.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    struct VulkanContext {
+    struct Context {
         VkInstance instance;
         VkDebugUtilsMessengerEXT debugger;
         VkSurfaceKHR surface;
@@ -17,7 +17,12 @@ namespace Dynamo::Graphics::Vulkan {
         VkCommandPool graphics_pool;
         VkCommandPool transfer_pool;
 
-        VulkanContext(const Display &display);
-        ~VulkanContext();
+        VkQueue graphics_queue;
+        VkQueue present_queue;
+        VkQueue compute_queue;
+        VkQueue transfer_queue;
+
+        Context(const Display &display);
+        ~Context();
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/DescriptorPool.hpp
+++ b/src/Graphics/Vulkan/DescriptorPool.hpp
@@ -3,6 +3,7 @@
 #include <unordered_map>
 #include <vector>
 
+#include <Graphics/Vulkan/Context.hpp>
 #include <vulkan/vulkan_core.h>
 
 namespace Dynamo::Graphics::Vulkan {
@@ -17,16 +18,16 @@ namespace Dynamo::Graphics::Vulkan {
     };
 
     class DescriptorPool {
-        VkDevice _device;
+        const Context &_context;
 
         std::unordered_map<VkDescriptorSetLayout, DescriptorPoolCache> _pools;
 
       public:
-        DescriptorPool(VkDevice device);
+        DescriptorPool(const Context &context);
         ~DescriptorPool();
 
-        VirtualDescriptorSet allocate_descriptor_set(VkDescriptorSetLayout layout);
+        VirtualDescriptorSet allocate(VkDescriptorSetLayout layout);
 
-        void free_descriptor_set(const VirtualDescriptorSet &set);
+        void free(const VirtualDescriptorSet &set);
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/FrameContext.cpp
+++ b/src/Graphics/Vulkan/FrameContext.cpp
@@ -24,9 +24,9 @@ namespace Dynamo::Graphics::Vulkan {
         }
     }
 
-    const FrameContext &FrameContextList::next() {
-        FrameContext &context = _contexts[_index];
-        _index = (_index + 1) % MAX_FRAMES_IN_FLIGHT;
-        return context;
-    }
+    const FrameContext &FrameContextList::get() const { return _contexts[_index]; }
+
+    void FrameContextList::advance() { _index = (_index + 1) % MAX_FRAMES_IN_FLIGHT; }
+
+    unsigned FrameContextList::index() const { return _index; }
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/FrameContext.hpp
+++ b/src/Graphics/Vulkan/FrameContext.hpp
@@ -6,7 +6,7 @@
 
 namespace Dynamo::Graphics::Vulkan {
     // Can't be too high or we'll experience latency
-    constexpr unsigned MAX_FRAMES_IN_FLIGHT = 3;
+    constexpr unsigned MAX_FRAMES_IN_FLIGHT = 2;
 
     struct FrameContext {
         VkFence sync_fence;
@@ -24,6 +24,10 @@ namespace Dynamo::Graphics::Vulkan {
         FrameContextList(VkDevice device, VkCommandPool command_pool);
         ~FrameContextList();
 
-        const FrameContext &next();
+        const FrameContext &get() const;
+
+        void advance();
+
+        unsigned index() const;
     };
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/MemoryPool.hpp
+++ b/src/Graphics/Vulkan/MemoryPool.hpp
@@ -3,6 +3,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include <Graphics/Texture.hpp>
+#include <Graphics/Vulkan/Context.hpp>
 #include <Graphics/Vulkan/PhysicalDevice.hpp>
 #include <Utils/Allocator.hpp>
 
@@ -39,8 +40,7 @@ namespace Dynamo::Graphics::Vulkan {
         };
         using MemoryGroup = std::vector<Memory>;
 
-        VkDevice _device;
-        const PhysicalDevice &_physical;
+        const Context &_context;
         std::vector<MemoryGroup> _groups;
 
         unsigned find_type_index(const VkMemoryRequirements &requirements, VkMemoryPropertyFlags properties) const;
@@ -48,7 +48,7 @@ namespace Dynamo::Graphics::Vulkan {
         VirtualMemory allocate_memory(const VkMemoryRequirements &requirements, VkMemoryPropertyFlags properties);
 
       public:
-        MemoryPool(VkDevice device, const PhysicalDevice &physical);
+        MemoryPool(const Context &context);
         ~MemoryPool();
 
         VirtualBuffer allocate_buffer(VkBufferUsageFlags usage, VkMemoryPropertyFlags properties, unsigned size);

--- a/src/Graphics/Vulkan/MeshRegistry.cpp
+++ b/src/Graphics/Vulkan/MeshRegistry.cpp
@@ -2,14 +2,12 @@
 #include <Graphics/Vulkan/Utils.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    MeshRegistry::MeshRegistry(VkDevice device,
-                               const PhysicalDevice &physical,
-                               MemoryPool &memory,
-                               VkCommandPool transfer_pool) :
-        _device(device),
-        _memory(memory) {
-        VkCommandBuffer_allocate(_device, transfer_pool, VK_COMMAND_BUFFER_LEVEL_PRIMARY, &_command_buffer, 1);
-        vkGetDeviceQueue(_device, physical.transfer_queues.index, 0, &_transfer_queue);
+    MeshRegistry::MeshRegistry(const Context &context, MemoryPool &memory) : _context(context), _memory(memory) {
+        VkCommandBuffer_allocate(_context.device,
+                                 _context.transfer_pool,
+                                 VK_COMMAND_BUFFER_LEVEL_PRIMARY,
+                                 &_command_buffer,
+                                 1);
     }
 
     MeshRegistry::~MeshRegistry() {
@@ -35,7 +33,7 @@ namespace Dynamo::Graphics::Vulkan {
 
         VkCommandBuffer_immediate_start(_command_buffer);
         vkCmdCopyBuffer(_command_buffer, staging.buffer, dst.buffer, 1, &region);
-        VkCommandBuffer_immediate_end(_command_buffer, _transfer_queue);
+        VkCommandBuffer_immediate_end(_command_buffer, _context.transfer_queue);
 
         _memory.free_buffer(staging);
     }

--- a/src/Graphics/Vulkan/MeshRegistry.hpp
+++ b/src/Graphics/Vulkan/MeshRegistry.hpp
@@ -22,16 +22,15 @@ namespace Dynamo::Graphics::Vulkan {
     };
 
     class MeshRegistry {
-        VkDevice _device;
+        const Context &_context;
         VkCommandBuffer _command_buffer;
-        VkQueue _transfer_queue;
         MemoryPool &_memory;
         SparseArray<Mesh, MeshInstance> _instances;
 
         void write_vertices(const void *src, VirtualBuffer &dst, unsigned size);
 
       public:
-        MeshRegistry(VkDevice device, const PhysicalDevice &physical, MemoryPool &memory, VkCommandPool transfer_pool);
+        MeshRegistry(const Context &context, MemoryPool &memory);
         ~MeshRegistry();
 
         MeshInstance &get(Mesh mesh);

--- a/src/Graphics/Vulkan/PhysicalDevice.cpp
+++ b/src/Graphics/Vulkan/PhysicalDevice.cpp
@@ -219,6 +219,7 @@ namespace Dynamo::Graphics::Vulkan {
     std::vector<const char *> PhysicalDevice::required_extensions() const {
         std::vector<const char *> required_extensions = {
             VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+            VK_EXT_DESCRIPTOR_INDEXING_EXTENSION_NAME,
         };
 
         // Check if portability subset extension is available

--- a/src/Graphics/Vulkan/PipelineRegistry.hpp
+++ b/src/Graphics/Vulkan/PipelineRegistry.hpp
@@ -7,6 +7,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include <Graphics/Pipeline.hpp>
+#include <Graphics/Vulkan/Context.hpp>
 #include <Graphics/Vulkan/ShaderRegistry.hpp>
 #include <Graphics/Vulkan/Swapchain.hpp>
 #include <Graphics/Vulkan/UniformRegistry.hpp>
@@ -107,8 +108,7 @@ namespace Dynamo::Graphics::Vulkan {
     };
 
     class PipelineRegistry {
-        VkDevice _device;
-        const PhysicalDevice &_physical;
+        const Context &_context;
 
         std::ofstream _ofstream;
         VkPipelineCache _pipeline_cache;
@@ -119,7 +119,7 @@ namespace Dynamo::Graphics::Vulkan {
         SparseArray<Pipeline, PipelineInstance> _instances;
 
       public:
-        PipelineRegistry(VkDevice device, const PhysicalDevice &physical, const std::string &filename);
+        PipelineRegistry(const Context &context, const std::string &cache_filename);
         ~PipelineRegistry();
 
         Pipeline build(const PipelineDescriptor &descriptor,

--- a/src/Graphics/Vulkan/ShaderRegistry.cpp
+++ b/src/Graphics/Vulkan/ShaderRegistry.cpp
@@ -5,9 +5,6 @@
 
 namespace Dynamo::Graphics::Vulkan {
     constexpr char INSTANCE_VAR_PREFIX[] = "instance";
-    constexpr VkShaderStageFlags SUPPORTED_SHADER_STAGES =
-        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_COMPUTE_BIT |
-        VK_SHADER_STAGE_TESSELLATION_CONTROL_BIT | VK_SHADER_STAGE_TESSELLATION_EVALUATION_BIT;
 
     ShaderRegistry::ShaderRegistry(VkDevice device) : _device(device) {}
 
@@ -133,7 +130,7 @@ namespace Dynamo::Graphics::Vulkan {
                 VkDescriptorSetLayoutBinding layout_binding;
                 layout_binding.binding = refl_binding.binding;
                 layout_binding.pImmutableSamplers = nullptr;
-                layout_binding.stageFlags = SUPPORTED_SHADER_STAGES;
+                layout_binding.stageFlags = VK_SHADER_STAGE_ALL;
                 layout_binding.descriptorType = static_cast<VkDescriptorType>(refl_binding.descriptor_type);
                 layout_binding.descriptorCount = 1;
                 for (unsigned k = 0; k < refl_binding.array.dims_count; k++) {
@@ -190,7 +187,7 @@ namespace Dynamo::Graphics::Vulkan {
             range.name = block.name;
             range.block.offset = block.offset;
             range.block.size = block.size;
-            range.block.stageFlags = SUPPORTED_SHADER_STAGES;
+            range.block.stageFlags = VK_SHADER_STAGE_ALL;
 
             module.push_constant_ranges.push_back(range);
             Log::info("* Push Constant Range (name: {}, offset: {}, size: {})",

--- a/src/Graphics/Vulkan/Swapchain.cpp
+++ b/src/Graphics/Vulkan/Swapchain.cpp
@@ -2,12 +2,9 @@
 #include <Graphics/Vulkan/Utils.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    Swapchain::Swapchain(VkDevice device,
-                         const PhysicalDevice &physical,
-                         const Display &display,
-                         std::optional<Swapchain> previous) :
-        device(device) {
-        SwapchainOptions options = physical.get_swapchain_options();
+    Swapchain::Swapchain(const Context &context, const Display &display, std::optional<Swapchain> previous) :
+        device(context.device) {
+        SwapchainOptions options = context.physical.get_swapchain_options();
 
         // Compute swapchain size
         Vec2 size = display.get_framebuffer_size();
@@ -42,7 +39,7 @@ namespace Dynamo::Graphics::Vulkan {
         // Create swapchain handle
         VkSwapchainCreateInfoKHR swapchain_info = {};
         swapchain_info.sType = VK_STRUCTURE_TYPE_SWAPCHAIN_CREATE_INFO_KHR;
-        swapchain_info.surface = physical.surface;
+        swapchain_info.surface = context.physical.surface;
         swapchain_info.preTransform = options.capabilities.currentTransform;
         swapchain_info.compositeAlpha = VK_COMPOSITE_ALPHA_OPAQUE_BIT_KHR;
         swapchain_info.presentMode = present_mode;
@@ -59,8 +56,8 @@ namespace Dynamo::Graphics::Vulkan {
 
         // Share images across graphics and present queue families
         std::array<unsigned, 2> queue_family_indices = {
-            physical.graphics_queues.index,
-            physical.present_queues.index,
+            context.physical.graphics_queues.index,
+            context.physical.present_queues.index,
         };
         if (queue_family_indices[0] != queue_family_indices[1]) {
             swapchain_info.imageSharingMode = VK_SHARING_MODE_CONCURRENT;

--- a/src/Graphics/Vulkan/Swapchain.hpp
+++ b/src/Graphics/Vulkan/Swapchain.hpp
@@ -5,6 +5,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include <Display.hpp>
+#include <Graphics/Vulkan/Context.hpp>
 #include <Graphics/Vulkan/PhysicalDevice.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
@@ -21,10 +22,7 @@ namespace Dynamo::Graphics::Vulkan {
 
         unsigned array_layers;
 
-        Swapchain(VkDevice device,
-                  const PhysicalDevice &physical,
-                  const Display &display,
-                  std::optional<Swapchain> previous = {});
+        Swapchain(const Context &context, const Display &display, std::optional<Swapchain> previous = {});
 
         // Need to bypass destructor call order to perform swapchain recreation
         void destroy();

--- a/src/Graphics/Vulkan/TextureRegistry.hpp
+++ b/src/Graphics/Vulkan/TextureRegistry.hpp
@@ -52,11 +52,9 @@ namespace Dynamo::Graphics::Vulkan {
     };
 
     class TextureRegistry {
-        VkDevice _device;
-        const PhysicalDevice &_physical;
+        const Context &_context;
         MemoryPool &_memory;
 
-        VkQueue _transfer_queue;
         VkCommandBuffer _command_buffer;
 
         std::unordered_map<SamplerSettings, VkSampler, SamplerSettings::Hash> _samplers;
@@ -69,10 +67,7 @@ namespace Dynamo::Graphics::Vulkan {
                           const VkImageSubresourceRange &subresources);
 
       public:
-        TextureRegistry(VkDevice device,
-                        const PhysicalDevice &physical,
-                        MemoryPool &memory,
-                        VkCommandPool transfer_pool);
+        TextureRegistry(const Context &context, MemoryPool &memory);
         ~TextureRegistry();
 
         Texture build(const TextureDescriptor &descriptor, const Swapchain &swapchain);

--- a/src/Graphics/Vulkan/UniformRegistry.hpp
+++ b/src/Graphics/Vulkan/UniformRegistry.hpp
@@ -5,6 +5,7 @@
 #include <vulkan/vulkan_core.h>
 
 #include <Graphics/Texture.hpp>
+#include <Graphics/Vulkan/Context.hpp>
 #include <Graphics/Vulkan/DescriptorPool.hpp>
 #include <Graphics/Vulkan/FrameContext.hpp>
 #include <Graphics/Vulkan/MemoryPool.hpp>
@@ -66,7 +67,7 @@ namespace Dynamo::Graphics::Vulkan {
     };
 
     class UniformRegistry {
-        VkDevice _device;
+        const Context &_context;
         MemoryPool &_memory;
         DescriptorPool &_descriptors;
         VirtualMemory _push_constant_buffer;
@@ -86,11 +87,7 @@ namespace Dynamo::Graphics::Vulkan {
         void free_group(const UniformGroupInstance &group);
 
       public:
-        UniformRegistry(VkDevice device,
-                        const PhysicalDevice &physical,
-                        MemoryPool &memory,
-                        DescriptorPool &descriptors,
-                        VkCommandPool transfer_pool);
+        UniformRegistry(const Context &context, MemoryPool &memory, DescriptorPool &descriptors);
         ~UniformRegistry();
 
         UniformGroup build(const std::vector<DescriptorSetLayout> &descriptor_set_layouts,

--- a/src/Graphics/Vulkan/Utils.cpp
+++ b/src/Graphics/Vulkan/Utils.cpp
@@ -1257,9 +1257,15 @@ namespace Dynamo::Graphics::Vulkan {
         // Enable descriptor indexing features
         VkPhysicalDeviceDescriptorIndexingFeatures descriptor_indexing = {};
         descriptor_indexing.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_INDEXING_FEATURES;
-        descriptor_indexing.descriptorBindingPartiallyBound = true;
         descriptor_indexing.runtimeDescriptorArray = true;
+        descriptor_indexing.descriptorBindingPartiallyBound = true;
         descriptor_indexing.descriptorBindingVariableDescriptorCount = true;
+        descriptor_indexing.descriptorBindingUniformBufferUpdateAfterBind = true;
+        descriptor_indexing.descriptorBindingStorageBufferUpdateAfterBind = true;
+        descriptor_indexing.descriptorBindingSampledImageUpdateAfterBind = true;
+        descriptor_indexing.descriptorBindingStorageImageUpdateAfterBind = true;
+        descriptor_indexing.descriptorBindingUniformTexelBufferUpdateAfterBind = true;
+        descriptor_indexing.descriptorBindingStorageTexelBufferUpdateAfterBind = true;
 
         std::vector<QueueFamilyRef> queue_families = physical.unique_queue_families();
         std::vector<const char *> extensions = physical.required_extensions();
@@ -1464,10 +1470,20 @@ namespace Dynamo::Graphics::Vulkan {
     VkDescriptorSetLayout VkDescriptorSetLayout_create(VkDevice device,
                                                        const VkDescriptorSetLayoutBinding *bindings,
                                                        unsigned binding_count) {
+        auto flags = VK_DESCRIPTOR_BINDING_PARTIALLY_BOUND_BIT | VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT;
+        std::vector<VkDescriptorBindingFlags> flag_set(binding_count, flags);
+        VkDescriptorSetLayoutBindingFlagsCreateInfo flags_info = {};
+        flags_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_BINDING_FLAGS_CREATE_INFO;
+        flags_info.pNext = nullptr;
+        flags_info.pBindingFlags = flag_set.data();
+        flags_info.bindingCount = flag_set.size();
+
         VkDescriptorSetLayoutCreateInfo layout_info = {};
         layout_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_LAYOUT_CREATE_INFO;
         layout_info.bindingCount = binding_count;
         layout_info.pBindings = bindings;
+        layout_info.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
+        layout_info.pNext = &flags_info;
 
         VkDescriptorSetLayout vk_layout;
         VkResult_check("Create Descriptor Set Layout",


### PR DESCRIPTION
* Use VK_SHADER_STAGE_ALL for descriptors and push constants
* Let descriptor pool support more descriptor types
* Enable update-after-bind descriptors
* Reduce MAX_FRAMES_IN_FLIGHT to 2