### PR TITLE
Streamline BufferInstance and TextureInstance structures

### DIFF
--- a/src/Graphics/Renderer.cpp
+++ b/src/Graphics/Renderer.cpp
@@ -14,7 +14,7 @@ namespace Dynamo::Graphics {
         _meshes(_context, _buffers),
         _shaders(_context.device),
         _pipelines(_context, root_asset_directory + "/vulkan_cache.bin"),
-        _uniforms(_context, _memory, _buffers, _descriptors),
+        _uniforms(_context, _buffers, _descriptors),
         _frame_contexts(_context.device, _context.graphics_pool),
         _forwardpass(VkRenderPass_create(_context.device,
                                          _context.physical.samples,
@@ -147,7 +147,7 @@ namespace Dynamo::Graphics {
 
     void Renderer::write_buffer(void *src, Buffer dst, unsigned dst_offset, unsigned length) {
         const BufferInstance &dst_instance = _buffers.get(dst);
-        unsigned char *dst_ptr = static_cast<unsigned char *>(dst_instance.memory.mapped);
+        unsigned char *dst_ptr = static_cast<unsigned char *>(dst_instance.mapped);
         std::memcpy(dst_ptr + dst_offset, src, length);
     }
 

--- a/src/Graphics/Vulkan/BufferRegistry.cpp
+++ b/src/Graphics/Vulkan/BufferRegistry.cpp
@@ -2,31 +2,87 @@
 #include <Graphics/Vulkan/Utils.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    BufferRegistry::BufferRegistry(const Context &context, MemoryPool &memory) : _context(context), _memory(memory) {}
+    constexpr unsigned MAX_BUFFER_USAGE = static_cast<unsigned>(BufferUsage::Staging) + 1;
+    constexpr unsigned MAX_MEMORY_PROPERTY = static_cast<unsigned>(MemoryProperty::DeviceLocal) + 1;
+
+    BufferRegistry::BufferRegistry(const Context &context, MemoryPool &memory) :
+        _context(context),
+        _memory(memory),
+        _groups(MAX_BUFFER_USAGE * MAX_MEMORY_PROPERTY) {}
 
     BufferRegistry::~BufferRegistry() {
-        _instances.foreach ([&](BufferInstance &instance) {
-            vkDestroyBuffer(_context.device, instance.buffer, nullptr);
-            _memory.free(instance.memory);
-        });
+        // Clear suballocations
+        _instances.clear();
+
+        // Clear primary buffers
+        for (const std::vector<PrimaryBuffer> &group : _groups) {
+            for (const PrimaryBuffer &primary : group) {
+                vkDestroyBuffer(_context.device, primary.buffer, nullptr);
+                _memory.free(primary.allocation);
+            }
+        }
+        _groups.clear();
     }
 
-    Buffer BufferRegistry::build(const BufferDescriptor &descriptor) {
-        VkBufferUsageFlags usage = convert_buffer_usage(descriptor.usage);
-        VkMemoryPropertyFlags properties = convert_memory_property(descriptor.property);
-
-        BufferInstance instance;
-        instance.buffer = VkBuffer_create(_context.device, usage, descriptor.size, nullptr, 0);
+    PrimaryBuffer
+    BufferRegistry::build_primary(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties) {
+        VkBuffer buffer = VkBuffer_create(_context.device, usage, size, nullptr, 0);
 
         // Allocate memory and bind to buffer
         VkMemoryRequirements requirements;
-        vkGetBufferMemoryRequirements(_context.device, instance.buffer, &requirements);
-        instance.memory = _memory.allocate(requirements, properties);
-        vkBindBufferMemory(_context.device, instance.buffer, instance.memory.memory, instance.memory.key.offset);
+        vkGetBufferMemoryRequirements(_context.device, buffer, &requirements);
+        VirtualMemory virtual_memory = _memory.allocate(requirements, properties);
+        vkBindBufferMemory(_context.device, buffer, virtual_memory.memory, virtual_memory.allocation.offset);
 
-        // TODO: Buffer suballocation
-        instance.offset = 0;
+        PrimaryBuffer primary;
+        primary.buffer = buffer;
+        primary.allocator = Allocator(size);
+        primary.allocation = virtual_memory.allocation;
+        primary.mapped = virtual_memory.mapped;
 
+        return primary;
+    }
+
+    unsigned BufferRegistry::find_type_index(BufferUsage usage, MemoryProperty properties) {
+        return static_cast<unsigned>(usage) * MAX_MEMORY_PROPERTY + static_cast<unsigned>(properties);
+    }
+
+    Buffer BufferRegistry::build(const BufferDescriptor &descriptor) {
+        // Find compatible primary buffer and suballocate
+        unsigned type = find_type_index(descriptor.usage, descriptor.property);
+        std::vector<PrimaryBuffer> &group = _groups[type];
+        for (unsigned index = 0; index < group.size(); index++) {
+            PrimaryBuffer &primary = group[index];
+            unsigned char *base_ptr = static_cast<unsigned char *>(primary.mapped);
+
+            std::optional<unsigned> result = primary.allocator.reserve(descriptor.size, 1);
+            if (result.has_value()) {
+                BufferInstance instance;
+                instance.buffer = primary.buffer;
+                instance.primary_group = type;
+                instance.primary_index = index;
+                instance.offset = result.value();
+                instance.mapped = nullptr;
+                if (base_ptr) {
+                    instance.mapped = base_ptr + instance.offset;
+                }
+                return _instances.insert(instance);
+            }
+        }
+
+        // None found, build new primary buffer and suballocate
+        VkDeviceSize size = std::max(static_cast<VkDeviceSize>(descriptor.size), MIN_ALLOCATION_SIZE);
+        VkBufferUsageFlags usage = convert_buffer_usage(descriptor.usage);
+        VkMemoryPropertyFlags properties = convert_memory_property(descriptor.property);
+        group.push_back(build_primary(size, usage, properties));
+
+        PrimaryBuffer &primary = group.back();
+        BufferInstance instance;
+        instance.buffer = primary.buffer;
+        instance.primary_group = type;
+        instance.primary_index = group.size() - 1;
+        instance.offset = primary.allocator.reserve(descriptor.size, 1).value();
+        instance.mapped = primary.mapped;
         return _instances.insert(instance);
     }
 
@@ -34,8 +90,8 @@ namespace Dynamo::Graphics::Vulkan {
 
     void BufferRegistry::destroy(Buffer buffer) {
         BufferInstance &instance = _instances.get(buffer);
-        vkDestroyBuffer(_context.device, instance.buffer, nullptr);
-        _memory.free(instance.memory);
+        PrimaryBuffer &primary = _groups[instance.primary_group][instance.primary_index];
+        primary.allocator.free(instance.offset);
         _instances.remove(buffer);
     }
 } // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/BufferRegistry.hpp
+++ b/src/Graphics/Vulkan/BufferRegistry.hpp
@@ -10,15 +10,29 @@
 namespace Dynamo::Graphics::Vulkan {
     struct BufferInstance {
         VkBuffer buffer;
-        VirtualMemory memory;
+        unsigned primary_group;
+        unsigned primary_index;
         unsigned offset;
+        void *mapped;
+    };
+
+    struct PrimaryBuffer {
+        VkBuffer buffer;
+        Allocator allocator;
+        Allocation allocation;
+        void *mapped;
     };
 
     class BufferRegistry {
         const Context &_context;
         MemoryPool &_memory;
 
+        std::vector<std::vector<PrimaryBuffer>> _groups;
         SparseArray<Buffer, BufferInstance> _instances;
+
+        PrimaryBuffer build_primary(VkDeviceSize size, VkBufferUsageFlags usage, VkMemoryPropertyFlags properties);
+
+        unsigned find_type_index(BufferUsage usage, MemoryProperty properties);
 
       public:
         BufferRegistry(const Context &context, MemoryPool &memory);

--- a/src/Graphics/Vulkan/MemoryPool.hpp
+++ b/src/Graphics/Vulkan/MemoryPool.hpp
@@ -8,7 +8,10 @@
 #include <Utils/Allocator.hpp>
 
 namespace Dynamo::Graphics::Vulkan {
-    struct AllocationKey {
+    // We only have 4096 guaranteed allocations. 32M * 4096 is over 100GB, so this should be enough.
+    constexpr VkDeviceSize MIN_ALLOCATION_SIZE = 32 * (1 << 20);
+
+    struct Allocation {
         unsigned offset;
         unsigned type;
         unsigned index;
@@ -16,7 +19,7 @@ namespace Dynamo::Graphics::Vulkan {
 
     struct VirtualMemory {
         VkDeviceMemory memory;
-        AllocationKey key;
+        Allocation allocation;
         void *mapped;
     };
 
@@ -39,6 +42,6 @@ namespace Dynamo::Graphics::Vulkan {
 
         VirtualMemory allocate(const VkMemoryRequirements &requirements, VkMemoryPropertyFlags properties);
 
-        void free(const VirtualMemory &allocation);
+        void free(const Allocation &allocation);
     };
 }; // namespace Dynamo::Graphics::Vulkan

--- a/src/Graphics/Vulkan/MeshRegistry.cpp
+++ b/src/Graphics/Vulkan/MeshRegistry.cpp
@@ -24,7 +24,7 @@ namespace Dynamo::Graphics::Vulkan {
 
         const BufferInstance &dst_instance = _buffers.get(dst);
         const BufferInstance &src_instance = _buffers.get(staging);
-        std::memcpy(src_instance.memory.mapped, src, size);
+        std::memcpy(src_instance.mapped, src, size);
 
         VkBufferCopy region;
         region.srcOffset = 0;

--- a/src/Graphics/Vulkan/TextureRegistry.hpp
+++ b/src/Graphics/Vulkan/TextureRegistry.hpp
@@ -50,7 +50,7 @@ namespace Dynamo::Graphics::Vulkan {
         VkImage image;
         VkImageView view;
         VkSampler sampler;
-        VirtualMemory memory;
+        Allocation allocation;
     };
 
     class TextureRegistry {

--- a/src/Graphics/Vulkan/UniformRegistry.cpp
+++ b/src/Graphics/Vulkan/UniformRegistry.cpp
@@ -5,12 +5,8 @@ namespace Dynamo::Graphics::Vulkan {
     // Limit of 128 bytes for push constants
     constexpr unsigned PUSH_CONSTANT_HEAP_SIZE = 128;
 
-    UniformRegistry::UniformRegistry(const Context &context,
-                                     MemoryPool &memory,
-                                     BufferRegistry &buffers,
-                                     DescriptorPool &descriptors) :
+    UniformRegistry::UniformRegistry(const Context &context, BufferRegistry &buffers, DescriptorPool &descriptors) :
         _context(context),
-        _memory(memory),
         _buffers(buffers),
         _descriptors(descriptors),
         _push_constant_buffer(PUSH_CONSTANT_HEAP_SIZE) {}
@@ -187,12 +183,12 @@ namespace Dynamo::Graphics::Vulkan {
         switch (var.type) {
         case UniformType::Descriptor: {
             const BufferInstance &buffer_instance = _buffers.get(var.descriptor.buffer);
-            char *dst = static_cast<char *>(buffer_instance.memory.mapped);
+            unsigned char *dst = static_cast<unsigned char *>(buffer_instance.mapped);
             std::memcpy(dst + index * var.descriptor.size, data, var.descriptor.size * count);
             break;
         }
         case UniformType::PushConstant: {
-            char *dst = static_cast<char *>(_push_constant_buffer.mapped(var.push_constant.offset));
+            unsigned char *dst = static_cast<unsigned char *>(_push_constant_buffer.mapped(var.push_constant.offset));
             std::memcpy(dst + index * var.push_constant.size, data, var.push_constant.size * count);
             break;
         }

--- a/src/Graphics/Vulkan/UniformRegistry.hpp
+++ b/src/Graphics/Vulkan/UniformRegistry.hpp
@@ -68,7 +68,6 @@ namespace Dynamo::Graphics::Vulkan {
 
     class UniformRegistry {
         const Context &_context;
-        MemoryPool &_memory;
         BufferRegistry &_buffers;
         DescriptorPool &_descriptors;
         VirtualBuffer _push_constant_buffer;
@@ -88,10 +87,7 @@ namespace Dynamo::Graphics::Vulkan {
         void free_group(const UniformGroupInstance &group);
 
       public:
-        UniformRegistry(const Context &context,
-                        MemoryPool &memory,
-                        BufferRegistry &buffers,
-                        DescriptorPool &descriptors);
+        UniformRegistry(const Context &context, BufferRegistry &buffers, DescriptorPool &descriptors);
         ~UniformRegistry();
 
         UniformGroup build(const std::vector<DescriptorSetLayout> &descriptor_set_layouts,


### PR DESCRIPTION
* Implement Buffer suballocation system
* Store only the Allocation key (and mapped ptr for buffers)